### PR TITLE
chore: Release hotdata-cli version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 📚 Documentation
 
 - *(skill)* Align hotdata skill with CLI behavior
+
 ## [0.2.0] - 2026-04-29
 
 ### 🚀 Features
@@ -24,8 +25,6 @@
 ### 💼 Other
 
 - *(release)* Bump geospatial skill version on release
-- *(deps)* Bump rustls-webpki to 0.103.13
-- Validate CHANGELOG sections match base branch on PRs
 
 ### 🚜 Refactor
 
@@ -38,6 +37,7 @@
 
 ### 🚀 Features
 
+- *(auth)* Add CLI auth session support (JWT access tokens, refresh, PKCE login)
 - *(indexes)* Workspace-wide list with filters and parallel fetch
 
 ### 💼 Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.1] - 2026-04-30
+
+### 📚 Documentation
+
+- *(skill)* Align hotdata skill with CLI behavior
 ## [0.2.0] - 2026-04-29
 
 ### 🚀 Features
@@ -19,6 +24,8 @@
 ### 💼 Other
 
 - *(release)* Bump geospatial skill version on release
+- *(deps)* Bump rustls-webpki to 0.103.13
+- Validate CHANGELOG sections match base branch on PRs
 
 ### 🚜 Refactor
 
@@ -31,7 +38,6 @@
 
 ### 🚀 Features
 
-- *(auth)* Add CLI auth session support (JWT access tokens, refresh, PKCE login)
 - *(indexes)* Workspace-wide list with filters and parallel fetch
 
 ### 💼 Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,7 +732,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anstyle",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
   Command line interface for <a href="https://www.hotdata.dev">Hotdata</a>.
   <br><br>
-  <img src="https://img.shields.io/badge/version-0.2.0-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.2.1-blue" alt="version">
   <a href="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml"><img src="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml/badge.svg" alt="build"></a>
   <a href="https://codecov.io/gh/hotdata-dev/hotdata-cli"><img src="https://codecov.io/gh/hotdata-dev/hotdata-cli/branch/main/graph/badge.svg" alt="coverage"></a>
 </p>

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -42,6 +42,8 @@ case "$COMMAND" in
         # step 2: bump versions, commit, push branch
         echo ""
         echo "→ Running cargo release (no publish, no tag)..."
+        # git-cliff (pre-release hook) is often installed via cargo install
+        export PATH="${HOME}/.cargo/bin:${PATH}"
         cargo release --no-publish --no-tag --no-confirm --allow-branch="$BRANCH" --execute "$VERSION"
 
         echo ""
@@ -79,6 +81,7 @@ case "$COMMAND" in
 
         echo ""
         echo "→ Running cargo release (tagging release)..."
+        export PATH="${HOME}/.cargo/bin:${PATH}"
         cargo release --no-confirm --execute
 
         echo ""

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.2.0
+version: 0.2.1
 ---
 
 # Hotdata Geospatial Skill


### PR DESCRIPTION
## Summary

Release preparation for **v0.2.1** (patch): version bump, `CHANGELOG.md`, README badge, and `hotdata-geospatial` skill frontmatter aligned with the crate. The `hotdata` skill was already at 0.2.1 on `main` from the docs PR.

## Changelog (0.2.1)

- **Documentation:** Align hotdata skill with CLI behavior (merged on `main`).

## Housekeeping

- `scripts/release.sh`: prepend `~/.cargo/bin` to `PATH` before `cargo release` so the `git-cliff` pre-release hook is found when `git-cliff` is installed via `cargo install`.

## After merge

Run `scripts/release.sh finish` from a clean `main` to tag and trigger dist (per [README](https://github.com/hotdata-dev/hotdata-cli#releasing)).