### PR TITLE
feat(wizard): render schema description, examples, defaults

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3,6 +3,27 @@ use crate::config;
 use crate::util;
 use crossterm::style::Stylize;
 use serde::de::DeserializeOwned;
+use std::time::Duration;
+
+/// Cap on any single HTTP request. Connection create + synchronous schema
+/// discovery against a slow remote catalog can take well over a minute, so
+/// this needs to be generous; 5 minutes leaves headroom while still bounding
+/// the worst case if the server genuinely hangs.
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// TCP keepalive cadence. Without this, macOS will drop a TCP connection
+/// that has been quiet (e.g. while the server is doing slow synchronous
+/// work) and reqwest surfaces it as "error sending request" even though the
+/// request itself completed server-side.
+const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30);
+
+fn build_http_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(HTTP_REQUEST_TIMEOUT)
+        .tcp_keepalive(TCP_KEEPALIVE_INTERVAL)
+        .build()
+        .expect("reqwest blocking client should always build with these defaults")
+}
 
 #[derive(Clone)]
 pub struct ApiClient {
@@ -48,7 +69,7 @@ impl ApiClient {
         };
 
         Self {
-            client: reqwest::blocking::Client::new(),
+            client: build_http_client(),
             api_key: access_token,
             api_url: profile_config.api_url.to_string(),
             workspace_id: workspace_id.map(String::from),
@@ -66,7 +87,7 @@ impl ApiClient {
     #[cfg(test)]
     pub(crate) fn test_new(api_url: &str, api_key: &str, workspace_id: Option<&str>) -> Self {
         Self {
-            client: reqwest::blocking::Client::new(),
+            client: build_http_client(),
             api_key: api_key.to_string(),
             api_url: api_url.to_string(),
             workspace_id: workspace_id.map(String::from),

--- a/src/connections_new.rs
+++ b/src/connections_new.rs
@@ -113,14 +113,25 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
 
     let field_type = field["type"].as_str().unwrap_or("string");
     let format = field["format"].as_str().unwrap_or("");
+    let description = field["description"].as_str();
+    let example = field["examples"]
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|v| v.as_str());
     let opt_hint = "optional — press Enter to skip";
+    let help_message: Option<String> = match (description, is_required) {
+        (Some(d), true) => Some(d.to_string()),
+        (Some(d), false) => Some(format!("{d} ({opt_hint})")),
+        (None, true) => None,
+        (None, false) => Some(opt_hint.to_string()),
+    };
 
     match (field_type, format) {
         ("string", "password") => {
             let label = format!("{key}:");
             let mut p = Password::new(&label).without_confirmation();
-            if !is_required {
-                p = p.with_help_message(opt_hint);
+            if let Some(h) = &help_message {
+                p = p.with_help_message(h);
             }
             let val = p.prompt().unwrap_or_else(|_| std::process::exit(0));
             if val.is_empty() && !is_required {
@@ -133,11 +144,14 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
         ("string", _) => {
             let label = format!("{key}:");
             let mut t = Text::new(&label);
-            if let Some(default) = field["default"].as_str() {
-                t = t.with_default(default);
+            let default = field["default"].as_str();
+            if let Some(d) = default {
+                t = t.with_default(d);
+            } else if let Some(e) = example {
+                t = t.with_placeholder(e);
             }
-            if !is_required {
-                t = t.with_help_message(opt_hint);
+            if let Some(h) = &help_message {
+                t = t.with_help_message(h);
             }
             let val = t.prompt().unwrap_or_else(|_| std::process::exit(0));
             if val.is_empty() && !is_required {
@@ -149,7 +163,7 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
 
         ("integer", _) => {
             let label = format!("{key}:");
-            let t = Text::new(&label).with_validator(move |input: &str| {
+            let mut t = Text::new(&label).with_validator(move |input: &str| {
                 if input.is_empty() {
                     if is_required {
                         return Ok(Validation::Invalid("This field is required".into()));
@@ -162,13 +176,12 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
                     Ok(Validation::Invalid("Must be a whole number".into()))
                 }
             });
-            let help_t;
-            let t = if !is_required {
-                help_t = t.with_help_message(opt_hint);
-                help_t
-            } else {
-                t
-            };
+            if let Some(e) = example {
+                t = t.with_placeholder(e);
+            }
+            if let Some(h) = &help_message {
+                t = t.with_help_message(h);
+            }
             let val = t.prompt().unwrap_or_else(|_| std::process::exit(0));
             if val.is_empty() && !is_required {
                 None
@@ -182,23 +195,28 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
         ("boolean", _) => {
             let label = format!("{key}:");
             let default = field["default"].as_bool().unwrap_or(false);
-            let val = Confirm::new(&label)
-                .with_default(default)
-                .prompt()
-                .unwrap_or_else(|_| std::process::exit(0));
+            let mut c = Confirm::new(&label).with_default(default);
+            if let Some(h) = &help_message {
+                c = c.with_help_message(h);
+            }
+            let val = c.prompt().unwrap_or_else(|_| std::process::exit(0));
             Some(Value::Bool(val))
         }
 
         ("array", _) => {
             let label = format!("{key}:");
-            let help = if is_required {
+            let array_hint = if is_required {
                 "Enter values separated by commas"
             } else {
                 "Enter values separated by commas — optional, press Enter to skip"
             };
+            let help = match description {
+                Some(d) => format!("{d} — {array_hint}"),
+                None => array_hint.to_string(),
+            };
             let val = Text::new(&label)
-                .with_placeholder("value1, value2, ...")
-                .with_help_message(help)
+                .with_placeholder(example.unwrap_or("value1, value2, ..."))
+                .with_help_message(&help)
                 .prompt()
                 .unwrap_or_else(|_| std::process::exit(0));
             if val.is_empty() && !is_required {

--- a/src/connections_new.rs
+++ b/src/connections_new.rs
@@ -114,10 +114,16 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
     let field_type = field["type"].as_str().unwrap_or("string");
     let format = field["format"].as_str().unwrap_or("");
     let description = field["description"].as_str();
-    let example = field["examples"]
+    // Accept both string and integer examples — `as_str` alone would silently
+    // miss schemas like `"examples": [8080]` on integer fields.
+    let example: Option<String> = field["examples"]
         .as_array()
         .and_then(|a| a.first())
-        .and_then(|v| v.as_str());
+        .and_then(|v| {
+            v.as_str()
+                .map(str::to_owned)
+                .or_else(|| v.as_i64().map(|n| n.to_string()))
+        });
     let opt_hint = "optional — press Enter to skip";
     let help_message: Option<String> = match (description, is_required) {
         (Some(d), true) => Some(d.to_string()),
@@ -147,7 +153,7 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
             let default = field["default"].as_str();
             if let Some(d) = default {
                 t = t.with_default(d);
-            } else if let Some(e) = example {
+            } else if let Some(e) = example.as_deref() {
                 t = t.with_placeholder(e);
             }
             if let Some(h) = &help_message {
@@ -176,7 +182,7 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
                     Ok(Validation::Invalid("Must be a whole number".into()))
                 }
             });
-            if let Some(e) = example {
+            if let Some(e) = example.as_deref() {
                 t = t.with_placeholder(e);
             }
             if let Some(h) = &help_message {
@@ -215,7 +221,7 @@ fn prompt_field(key: &str, field: &Value, is_required: bool) -> Option<Value> {
                 None => array_hint.to_string(),
             };
             let val = Text::new(&label)
-                .with_placeholder(example.unwrap_or("value1, value2, ..."))
+                .with_placeholder(example.as_deref().unwrap_or("value1, value2, ..."))
                 .with_help_message(&help)
                 .prompt()
                 .unwrap_or_else(|_| std::process::exit(0));


### PR DESCRIPTION
## Summary

Two small CLI changes that go alongside [runtimedb #408](https://github.com/hotdata-dev/runtimedb/pull/408):

1. **`feat(wizard): render schema description, examples, and defaults`** (`src/connections_new.rs`). The schema-driven `connections new` wizard previously ignored every JSON Schema annotation except `default` (and only on plain string fields). Now `prompt_field` also reads `description` (rendered as inquire help text on every supported field type — string, password, integer, boolean, array) and `examples[0]` (rendered as the inquire placeholder for plain strings, integers, and arrays when no `default` is set; password fields skip the placeholder by design and rely on the description). When a field is optional, the description and "optional — press Enter to skip" hint are concatenated rather than one displacing the other.

2. **`fix(api): add request timeout and tcp keepalive`** (`src/api.rs`). The blocking HTTP client was built via `reqwest::blocking::Client::new()` with no explicit configuration. On macOS this surfaces as `error sending request` when a request is in flight long enough for the OS to drop the quiet TCP connection (e.g. while runtimedb is doing slow synchronous work like ducklake schema discovery against a remote catalog). Add an explicit 5-min request timeout (bounds the worst case if the server genuinely hangs) and a 30s TCP keepalive (keeps the socket warm across long synchronous server work).

## Why

The schema-metadata change is what makes runtimedb #408 actually useful in the CLI. Without it, the new descriptions on `credentials_json` for ducklake / bigquery / snowflake are sent over the wire but never reach the user — the wizard would still show bare `credentials_json:` prompts. Both changes are generic and schema-driven; no per-connector code anywhere in the CLI.

The timeout fix was hit live while testing the ducklake wizard against a local runtimedb: the wizard's POST landed correctly server-side and the connection was created, but the CLI gave up waiting before discovery returned and printed `error sending request`. Adding `tcp_keepalive` is what actually fixes the symptom (prevents the OS from dropping the quiet socket); the explicit `timeout` is belt-and-suspenders for "what if the server actually hangs."

## Wire compatibility

Pure additive client behaviour. Nothing in the wire contract changes:
- The wizard still POSTs the same shape it did before.
- The HTTP client still talks plain HTTP/1.1 + JSON. Just keeps the TCP socket alive and bounds the worst case.

## What this branch does NOT contain

- Multi-field auth bundling (which an earlier iteration had). The runtimedb PR keeps multi-credential connectors on a single `credentials_json` field, so the wizard never has multi-field auth to bundle.
- Changes to the 9 other `Client::new()` sites in `jwt.rs` / `auth.rs` / `skill.rs`. We can consolidate them in a follow-up if you want; this PR only touches the construction sites in `ApiClient`.

## Test plan

- [x] `cargo test` — 121 tests pass locally.
- [x] `cargo build` clean.
- [x] Manual end-to-end against a locally-running runtimedb on the matching `feat/credentials-json-schema-metadata` branch:
  - `connections create list ducklake --output json` — new descriptions/examples/defaults flow through.
  - `connections new` for ducklake — every prompt now shows description help text; `s3_endpoint` / `s3_region` show defaults; `credentials_json` prompt shows the JSON shape from the description.
  - Connection POST + discovery still completes despite the long-running synchronous discovery (no more `error sending request`).