### PR TITLE
chore: ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store


### PR DESCRIPTION
## Summary
- Add `.DS_Store` to `.gitignore` so Finder metadata does not appear as repo noise.

## Test plan
- [x] N/A (gitignore only)