### PR TITLE
feat(auth): add hotdata auth register command

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -207,7 +207,7 @@ fn receive_callback(
     *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
     body {{
       font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
-      background: #111827;
+      background: #121212;
       color: #e5e7eb;
       display: flex;
       align-items: center;
@@ -215,8 +215,8 @@ fn receive_callback(
       min-height: 100vh;
     }}
     .card {{
-      background: #1f2937;
-      border: 1px solid #374151;
+      background: #1a1a1a;
+      border: 1px solid #333333;
       border-radius: 0.5rem;
       padding: 2.5rem;
       max-width: 420px;


### PR DESCRIPTION
## Summary

- Adds `hotdata auth register` command with GitHub as the default provider
- Supports `--email` flag for email-based registration flow
- Extracts `run_browser_auth` helper shared between login and register (PKCE browser handoff)
- Fixes CLI OAuth callback page colors to match the web app custom gray palette (`#121212` bg, `#1a1a1a` card, `#333333` border)
- Splits search and analytics sub-skills; improves skill workflows

## Test plan

- [x] `hotdata auth register` opens browser to GitHub OAuth flow
- [x] `hotdata auth register --email user@example.com` opens browser to email registration flow
- [x] After completing registration, the callback page colors match https://app.hotdata.dev/accounts/login/
- [x] `hotdata auth login` still works as before (shared helper not regressed)
- [x] Unit tests pass: `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)