### PR TITLE
chore: Release hotdata-cli version 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,61 @@
+## [0.2.4] - 2026-05-19
+
+### 🚀 Features
+
+- *(update)* Add update command
+- *(skills)* Split search and analytics sub-skills; improve workflows.
+- *(auth)* Add hotdata auth register command
+- *(auth)* Default register to GitHub, add --email flag
+
+### 🐛 Bug Fixes
+
+- *(auth)* Align CLI callback page colors with web app theme
+
+### 🚜 Refactor
+
+- *(auth)* Extract run_browser_auth helper; add tests for exchange_cli_register_code
+
+### 📚 Documentation
+
+- *(skill)* Add epic flow checklists to core WORKFLOWS.
 ## [0.2.3] - 2026-05-19
 
 ### 🚀 Features
 
-- *(databases)* Add managed databases CLI for parquet table loads (#82)
 - *(sandbox)* Add sandbox JWT support
 - *(tty)* Add no-input flag and tty checks for interactive commands
+- *(databases)* Add managed databases CLI for parquet table loads for parquet table loads.
 
 ### 🐛 Bug Fixes
 
-- *(deps)* Bump openssl to 0.10.79 for CVE fixes (#77)
+- *(deps)* Bump openssl to 0.10.79 for CVE fixes
+- *(changelog)* Correct 0.2.3 section and preserve released history.
 
 ### 💼 Other
 
-- Ignore macOS metadata files (#81)
+- Ignore macOS metadata files
 
 ### 📚 Documentation
 
-- *(skill)* Document managed databases commands
+- *(skill)* Document managed databases commands.
 ## [0.2.2] - 2026-05-04
 
 ### 🚀 Features
 
 - *(wizard)* Render schema description, examples, defaults (#75)
 
+### 🐛 Bug Fixes
+
+- *(changelog)* Preserve released sections from main for CI validate
 ## [0.2.1] - 2026-04-30
+
+### 🐛 Bug Fixes
+
+- *(changelog)* Keep prior release sections identical to main
 
 ### 📚 Documentation
 
 - *(skill)* Align hotdata skill with CLI behavior
-
 ## [0.2.0] - 2026-04-29
 
 ### 🚀 Features
@@ -50,6 +77,8 @@
 ### 💼 Other
 
 - *(release)* Bump geospatial skill version on release
+- *(deps)* Bump rustls-webpki to 0.103.13
+- Validate CHANGELOG sections match base branch on PRs
 
 ### 🚜 Refactor
 
@@ -62,7 +91,6 @@
 
 ### 🚀 Features
 
-- *(auth)* Add CLI auth session support (JWT access tokens, refresh, PKCE login)
 - *(indexes)* Workspace-wide list with filters and parallel fetch
 
 ### 💼 Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### 🚀 Features
 
-- *(update)* Add update command
-- *(skills)* Split search and analytics sub-skills; improve workflows.
-- *(auth)* Add hotdata auth register command
-- *(auth)* Default register to GitHub, add --email flag
+- *(auth)* Add `hotdata auth register` command (#85, #86)
+- *(auth)* Default register to GitHub; add `--email` flag
+- *(update)* Add `hotdata update` command
+- *(skills)* Split bundled skills into `hotdata-search` and `hotdata-analytics` (#84)
 
 ### 🐛 Bug Fixes
 
@@ -13,49 +13,42 @@
 
 ### 🚜 Refactor
 
-- *(auth)* Extract run_browser_auth helper; add tests for exchange_cli_register_code
+- *(auth)* Extract `run_browser_auth` helper; add tests for `exchange_cli_register_code`
 
 ### 📚 Documentation
 
-- *(skill)* Add epic flow checklists to core WORKFLOWS.
+- *(skill)* Epic flow checklists, datasets vs databases workflows, tag-only release finish (#84)
 ## [0.2.3] - 2026-05-19
 
 ### 🚀 Features
 
+- *(databases)* Add managed databases CLI for parquet table loads (#82)
 - *(sandbox)* Add sandbox JWT support
 - *(tty)* Add no-input flag and tty checks for interactive commands
-- *(databases)* Add managed databases CLI for parquet table loads for parquet table loads.
 
 ### 🐛 Bug Fixes
 
-- *(deps)* Bump openssl to 0.10.79 for CVE fixes
-- *(changelog)* Correct 0.2.3 section and preserve released history.
+- *(deps)* Bump openssl to 0.10.79 for CVE fixes (#77)
 
 ### 💼 Other
 
-- Ignore macOS metadata files
+- Ignore macOS metadata files (#81)
 
 ### 📚 Documentation
 
-- *(skill)* Document managed databases commands.
+- *(skill)* Document managed databases commands
 ## [0.2.2] - 2026-05-04
 
 ### 🚀 Features
 
 - *(wizard)* Render schema description, examples, defaults (#75)
 
-### 🐛 Bug Fixes
-
-- *(changelog)* Preserve released sections from main for CI validate
 ## [0.2.1] - 2026-04-30
-
-### 🐛 Bug Fixes
-
-- *(changelog)* Keep prior release sections identical to main
 
 ### 📚 Documentation
 
 - *(skill)* Align hotdata skill with CLI behavior
+
 ## [0.2.0] - 2026-04-29
 
 ### 🚀 Features
@@ -77,8 +70,6 @@
 ### 💼 Other
 
 - *(release)* Bump geospatial skill version on release
-- *(deps)* Bump rustls-webpki to 0.103.13
-- Validate CHANGELOG sections match base branch on PRs
 
 ### 🚜 Refactor
 
@@ -91,6 +82,7 @@
 
 ### 🚀 Features
 
+- *(auth)* Add CLI auth session support (JWT access tokens, refresh, PKCE login)
 - *(indexes)* Workspace-wide list with filters and parallel fetch
 
 ### 💼 Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anstyle",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
   Command line interface for <a href="https://www.hotdata.dev">Hotdata</a>.
   <br><br>
-  <img src="https://img.shields.io/badge/version-0.2.3-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.2.4-blue" alt="version">
   <a href="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml"><img src="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml/badge.svg" alt="build"></a>
   <a href="https://codecov.io/gh/hotdata-dev/hotdata-cli"><img src="https://codecov.io/gh/hotdata-dev/hotdata-cli/branch/main/graph/badge.svg" alt="coverage"></a>
 </p>

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-analytics
 description: Use this skill when the user wants OLAP-style SQL analytics in Hotdata — aggregations, GROUP BY, JOINs, reporting, exploratory queries, query run history, stored results, or materialized follow-up tables (Chain via datasets or managed databases). Activate for "analyze", "aggregate", "rollup", "pivot", "report", "metrics", "GROUP BY", "query history", "past queries", "query runs", "stored results", "materialize", "chain", "intermediate table", or sorted indexes for filters/range scans. Do not load for BM25/vector search or geospatial SQL — use hotdata-search or hotdata-geospatial. Requires the core hotdata skill for connections, tables, datasets, and auth.
-version: 0.2.3
+version: 0.2.4
 ---
 
 # Hotdata Analytics Skill

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.2.3
+version: 0.2.4
 ---
 
 # Hotdata Geospatial Skill

--- a/skills/hotdata-search/SKILL.md
+++ b/skills/hotdata-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-search
 description: Use this skill when the user wants full-text search, BM25 keyword search, vector similarity search, semantic search, embeddings, or retrieval indexes in Hotdata. Activate for "hotdata search", "BM25", "full-text", "vector search", "semantic search", "similarity", "embedding", "embedding provider", "create an index" (bm25 or vector), "list indexes" for search, or SQL using bm25_search or vector_distance. Do not load for general SQL analytics (aggregations, GROUP BY) or geospatial work — use hotdata-analytics or hotdata-geospatial instead. Requires the core hotdata skill for auth and workspace basics.
-version: 0.2.3
+version: 0.2.4
 ---
 
 # Hotdata Search Skill

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata
 description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, datasets, tables, basic SQL query, sandboxes, workspace context (context:DATAMODEL), jobs, and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "list datasets", "create a dataset", "execute a query", "list sandboxes", "workspace context", "context:DATAMODEL", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
-version: 0.2.3
+version: 0.2.4
 ---
 
 # Hotdata CLI Skill


### PR DESCRIPTION
## Summary

Release 0.2.4 — version bump, changelog, and skill version alignment.

### Since v0.2.3

- hotdata auth register (GitHub default, --email) (#85, #86)
- hotdata update command
- Bundled skills split: hotdata-search, hotdata-analytics (#84)
- Skill workflow docs (epic flows, datasets vs databases)

## Test plan

- [ ] CI green (changelog validate, tests)
- [ ] Review CHANGELOG 0.2.4 section
- [ ] After merge: git checkout main && git pull && scripts/release.sh finish