### PR TITLE
chore: Release hotdata-cli version 0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.2.6] - 2026-05-19
+
+### 🚀 Features
+
+- *(search)* Infer `--type` and `--column` from table indexes; schema defaults to `public` (#90)
+
+### 🐛 Bug Fixes
+
+- *(search)* Explicit error when a search index has no columns (#90)
+
 ## [0.2.5] - 2026-05-19
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anstyle",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"


### PR DESCRIPTION
Bump version to 0.2.6 and update CHANGELOG.

### Changes
- *(search)* Infer `--type` and `--column` from table indexes; schema defaults to `public` (#90)
- *(search)* Explicit error when a search index has no columns (#90)