### PR TITLE
feat(context): scope context commands to active database

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -228,11 +228,15 @@ pub enum Commands {
         command: Option<SandboxCommands>,
     },
 
-    /// Sync workspace text context with local Markdown (`./<NAME>.md` in the current directory)
+    /// Sync database context with local Markdown (`./<NAME>.md` in the current directory)
     Context {
         /// Workspace ID (defaults to first workspace from login)
         #[arg(long, short = 'w', global = true)]
         workspace_id: Option<String>,
+
+        /// Database ID (defaults to active database set via 'hotdata databases set')
+        #[arg(long, short = 'd', global = true)]
+        database_id: Option<String>,
 
         #[command(subcommand)]
         command: ContextCommands,
@@ -852,7 +856,7 @@ pub enum ContextCommands {
         name: String,
     },
 
-    /// Download context from the workspace to ./<NAME>.md
+    /// Download context from the database to ./<NAME>.md
     Pull {
         /// Context name (trailing `.md` ignored, e.g. `USER.md` → `USER`)
         name: String,
@@ -866,7 +870,7 @@ pub enum ContextCommands {
         dry_run: bool,
     },
 
-    /// Upload ./<NAME>.md to the workspace as named context
+    /// Upload ./<NAME>.md to the database as named context
     Push {
         /// Context name (trailing `.md` ignored, e.g. `USER.md` → `USER`; reads `./USER.md`)
         name: String,

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-//! Workspace context: `/v1/context` sync with `./{NAME}.md` in the current directory.
+//! Database context: `/v1/databases/{id}/context` sync with `./{NAME}.md` in the current directory.
 
 use crate::api::ApiClient;
 use crossterm::style::Stylize;
@@ -28,7 +28,7 @@ static RESERVED_WORDS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 });
 
 #[derive(Debug, Deserialize, Serialize)]
-struct WorkspaceContextEntry {
+struct DatabaseContextEntry {
     name: String,
     content: String,
     updated_at: String,
@@ -36,17 +36,17 @@ struct WorkspaceContextEntry {
 
 #[derive(Deserialize)]
 struct ListResponse {
-    contexts: Vec<WorkspaceContextEntry>,
+    contexts: Vec<DatabaseContextEntry>,
 }
 
 #[derive(Deserialize)]
 struct GetResponse {
-    context: WorkspaceContextEntry,
+    context: DatabaseContextEntry,
 }
 
 #[derive(Deserialize)]
 struct UpsertResponse {
-    context: WorkspaceContextEntry,
+    context: DatabaseContextEntry,
 }
 
 /// Normalizes a context name from the CLI: trims, takes the final path segment, and strips a
@@ -124,9 +124,10 @@ fn local_md_path(name: &str) -> PathBuf {
 
 fn fetch_context(
     api: &ApiClient,
+    database_id: &str,
     name: &str,
-) -> Result<WorkspaceContextEntry, reqwest::StatusCode> {
-    let path = format!("/context/{name}");
+) -> Result<DatabaseContextEntry, reqwest::StatusCode> {
+    let path = format!("/databases/{database_id}/context/{name}");
     let (status, body) = api.get_raw(&path);
     if status == reqwest::StatusCode::NOT_FOUND {
         return Err(status);
@@ -143,11 +144,11 @@ fn fetch_context(
     Ok(parsed.context)
 }
 
-pub fn list(workspace_id: &str, prefix: Option<&str>, format: &str) {
+pub fn list(workspace_id: &str, database_id: &str, prefix: Option<&str>, format: &str) {
     let api = ApiClient::new(Some(workspace_id));
-    let body: ListResponse = api.get("/context");
+    let body: ListResponse = api.get(&format!("/databases/{database_id}/context"));
 
-    let mut rows: Vec<WorkspaceContextEntry> = body.contexts;
+    let mut rows: Vec<DatabaseContextEntry> = body.contexts;
     if let Some(p) = prefix {
         rows.retain(|c| c.name.starts_with(p));
     }
@@ -176,7 +177,7 @@ pub fn list(workspace_id: &str, prefix: Option<&str>, format: &str) {
     }
 }
 
-pub fn show(workspace_id: &str, name: &str) {
+pub fn show(workspace_id: &str, database_id: &str, name: &str) {
     let name = normalize_context_cli_name(name);
     if let Err(e) = validate_context_stem(&name) {
         eprintln!("error: {e}");
@@ -184,7 +185,7 @@ pub fn show(workspace_id: &str, name: &str) {
     }
 
     let api = ApiClient::new(Some(workspace_id));
-    match fetch_context(&api, &name) {
+    match fetch_context(&api, database_id, &name) {
         Ok(ctx) => {
             print!("{}", ctx.content);
             if !ctx.content.ends_with('\n') {
@@ -194,7 +195,7 @@ pub fn show(workspace_id: &str, name: &str) {
         Err(reqwest::StatusCode::NOT_FOUND) => {
             eprintln!(
                 "{}",
-                format!("error: no context named '{name}' in this workspace.").red()
+                format!("error: no context named '{name}' in this database.").red()
             );
             eprintln!(
                 "{}",
@@ -207,7 +208,7 @@ pub fn show(workspace_id: &str, name: &str) {
     }
 }
 
-pub fn pull(workspace_id: &str, name: &str, force: bool, dry_run: bool) {
+pub fn pull(workspace_id: &str, database_id: &str, name: &str, force: bool, dry_run: bool) {
     let name = normalize_context_cli_name(name);
     if let Err(e) = validate_context_stem(&name) {
         eprintln!("error: {e}");
@@ -229,12 +230,12 @@ pub fn pull(workspace_id: &str, name: &str, force: bool, dry_run: bool) {
     }
 
     let api = ApiClient::new(Some(workspace_id));
-    let ctx = match fetch_context(&api, &name) {
+    let ctx = match fetch_context(&api, database_id, &name) {
         Ok(c) => c,
         Err(reqwest::StatusCode::NOT_FOUND) => {
             eprintln!(
                 "{}",
-                format!("error: no context named '{name}' in this workspace.").red()
+                format!("error: no context named '{name}' in this database.").red()
             );
             std::process::exit(1);
         }
@@ -270,7 +271,7 @@ pub fn pull(workspace_id: &str, name: &str, force: bool, dry_run: bool) {
     );
 }
 
-pub fn push(workspace_id: &str, name: &str, dry_run: bool) {
+pub fn push(workspace_id: &str, database_id: &str, name: &str, dry_run: bool) {
     let name = normalize_context_cli_name(name);
     if let Err(e) = validate_context_stem(&name) {
         eprintln!("error: {e}");
@@ -310,7 +311,7 @@ pub fn push(workspace_id: &str, name: &str, dry_run: bool) {
 
     let api = ApiClient::new(Some(workspace_id));
     let body = json!({ "name": &name, "content": content });
-    let resp: UpsertResponse = api.post("/context", &body);
+    let resp: UpsertResponse = api.post(&format!("/databases/{database_id}/context"), &body);
 
     println!(
         "{}",

--- a/src/datasets.rs
+++ b/src/datasets.rs
@@ -107,7 +107,7 @@ fn create_dataset(
 
 pub fn create_from_query(workspace_id: &str, sql: &str, description: Option<&str>, name: &str) {
     let api = ApiClient::new(Some(workspace_id));
-    create_dataset(&api, description, name, json!({ "sql": sql }));
+    create_dataset(&api, description, name, json!({ "type": "sql_query", "sql": sql }));
 }
 
 pub fn create_from_saved_query(
@@ -117,7 +117,7 @@ pub fn create_from_saved_query(
     name: &str,
 ) {
     let api = ApiClient::new(Some(workspace_id));
-    create_dataset(&api, description, name, json!({ "saved_query_id": query_id }));
+    create_dataset(&api, description, name, json!({ "type": "saved_query", "saved_query_id": query_id }));
 }
 
 pub fn list(workspace_id: &str, limit: Option<u32>, offset: Option<u32>, format: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -939,21 +939,32 @@ fn main() {
             }
             Commands::Context {
                 workspace_id,
+                database_id,
                 command,
             } => {
                 let workspace_id = resolve_workspace(workspace_id);
+                let database_id = database_id
+                    .or_else(|| config::load_current_database("default", &workspace_id))
+                    .unwrap_or_else(|| {
+                        eprintln!(
+                            "error: no active database. Use 'hotdata databases set <id>' to set one, or pass --database."
+                        );
+                        std::process::exit(1);
+                    });
                 match command {
                     ContextCommands::List { output, prefix } => {
-                        context::list(&workspace_id, prefix.as_deref(), &output)
+                        context::list(&workspace_id, &database_id, prefix.as_deref(), &output)
                     }
-                    ContextCommands::Show { name } => context::show(&workspace_id, &name),
+                    ContextCommands::Show { name } => {
+                        context::show(&workspace_id, &database_id, &name)
+                    }
                     ContextCommands::Pull {
                         name,
                         force,
                         dry_run,
-                    } => context::pull(&workspace_id, &name, force, dry_run),
+                    } => context::pull(&workspace_id, &database_id, &name, force, dry_run),
                     ContextCommands::Push { name, dry_run } => {
-                        context::push(&workspace_id, &name, dry_run)
+                        context::push(&workspace_id, &database_id, &name, dry_run)
                     }
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -947,7 +947,7 @@ fn main() {
                     .or_else(|| config::load_current_database("default", &workspace_id))
                     .unwrap_or_else(|| {
                         eprintln!(
-                            "error: no active database. Use 'hotdata databases set <id>' to set one, or pass --database."
+                            "error: no active database. Use 'hotdata databases set <id>' to set one, or pass --database-id."
                         );
                         std::process::exit(1);
                     });


### PR DESCRIPTION
## Summary

- Context commands now call `/databases/{database_id}/context` instead of `/context`
- Adds `--database` / `-d` flag to `hotdata context`; falls back to the active database set via `hotdata databases set`
- Exits with a clear error if no database is active and no `--database` flag is passed
- Error messages updated from "workspace" to "database" throughout

## Requires

hotdata-dev/runtimedb#474 — which implements the `/databases/{database_id}/context` endpoints and migrates storage from `workspace_contexts` to `database_contexts`.