### PR TITLE
chore: Release hotdata-cli version 0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.2.8] - 2026-05-22
+
+### 🚀 Features
+
+- *(context)* Scope context commands to active database; `hotdata context` now calls `/databases/{id}/context` and requires `--database-id` or an active database set via `databases set` (#98)
+- *(databases)* Add `--expires-at` flag to `databases create`; accepts relative durations (`24h`, `7d`) or RFC 3339 timestamps (#97)
+- *(datasets)* Remove upload/URL/file create paths; `datasets create` now requires exactly one of `--sql` or `--query-id` (#95)
+- *(databases)* Migrate CLI to dedicated `/databases` API; `databases set` saves active database; `X-Database-Id` header sent automatically on all requests (#94)
+
+### 🐛 Bug Fixes
+
+- *(datasets)* Add missing `type` discriminator to dataset source payloads sent to API
+- *(context)* Correct `--database-id` flag name in error message
+
 ## [0.2.7] - 2026-05-20
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anstyle",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-analytics
 description: Use this skill when the user wants OLAP-style SQL analytics in Hotdata — aggregations, GROUP BY, JOINs, reporting, exploratory queries, query run history, stored results, or materialized follow-up tables (Chain via datasets or managed databases). Activate for "analyze", "aggregate", "rollup", "pivot", "report", "metrics", "GROUP BY", "query history", "past queries", "query runs", "stored results", "materialize", "chain", "intermediate table", or sorted indexes for filters/range scans. Do not load for BM25/vector search or geospatial SQL — use hotdata-search or hotdata-geospatial. Requires the core hotdata skill for connections, tables, datasets, and auth.
-version: 0.2.7
+version: 0.2.8
 ---
 
 # Hotdata Analytics Skill

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.2.7
+version: 0.2.8
 ---
 
 # Hotdata Geospatial Skill

--- a/skills/hotdata-search/SKILL.md
+++ b/skills/hotdata-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-search
 description: Use this skill when the user wants full-text search, BM25 keyword search, vector similarity search, semantic search, embeddings, or retrieval indexes in Hotdata. Activate for "hotdata search", "BM25", "full-text", "vector search", "semantic search", "similarity", "embedding", "embedding provider", "create an index" (bm25 or vector), "list indexes" for search, or SQL using bm25_search or vector_distance. Do not load for general SQL analytics (aggregations, GROUP BY) or geospatial work — use hotdata-analytics or hotdata-geospatial instead. Requires the core hotdata skill for auth and workspace basics.
-version: 0.2.7
+version: 0.2.8
 ---
 
 # Hotdata Search Skill

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata
 description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, datasets, tables, basic SQL query, sandboxes, workspace context (context:DATAMODEL), jobs, and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "list datasets", "create a dataset", "execute a query", "list sandboxes", "workspace context", "context:DATAMODEL", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
-version: 0.2.7
+version: 0.2.8
 ---
 
 # Hotdata CLI Skill


### PR DESCRIPTION
## Release 0.2.8

### 🚀 Features

- *(context)* Scope context commands to active database — `hotdata context` now calls `/databases/{id}/context` and requires `--database-id` or an active database set via `databases set` (#98)
- *(databases)* Add `--expires-at` flag to `databases create`; accepts relative durations (`24h`, `7d`) or RFC 3339 timestamps (#97)
- *(datasets)* Remove upload/URL/file create paths; `datasets create` now requires exactly one of `--sql` or `--query-id` (#95)
- *(databases)* Migrate CLI to dedicated `/databases` API; `databases set` saves active database; `X-Database-Id` header sent automatically on all requests (#94)

### 🐛 Bug Fixes

- *(datasets)* Add missing `type` discriminator to dataset source payloads
- *(context)* Correct `--database-id` flag name in error message