### PR TITLE
feat(query): add --database flag and improve post-load UX

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -122,6 +122,12 @@ impl ApiClient {
         }
     }
 
+    /// Override the database ID for a single query without touching config.
+    pub fn with_database(mut self, database_id: &str) -> Self {
+        self.database_id = Some(database_id.to_string());
+        self
+    }
+
     /// Test-only client (no config load). Used with a local mock HTTP server.
     #[cfg(test)]
     pub(crate) fn test_new(api_url: &str, api_key: &str, workspace_id: Option<&str>) -> Self {

--- a/src/command.rs
+++ b/src/command.rs
@@ -38,6 +38,10 @@ pub enum Commands {
         #[arg(long)]
         connection: Option<String>,
 
+        /// Run query against a specific managed database (overrides the current database set via `databases set`)
+        #[arg(long, short = 'd')]
+        database: Option<String>,
+
         /// Output format
         #[arg(long = "output", short = 'o', default_value = "table", value_parser = ["table", "json", "csv"])]
         output: String,

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -463,6 +463,22 @@ pub fn create(
                 println!("description: {desc}");
             }
             println!("id:          {}", result.id);
+            println!();
+            println!(
+                "{}",
+                format!(
+                    concat!(
+                        "Load a table:\n",
+                        "  hotdata databases load --file <path.parquet> {}.<table_name>\n",
+                        "\nQuery with:\n",
+                        "  hotdata query --database {} \"SELECT * FROM default.public.<table> LIMIT 10\"\n",
+                        "\n  Tip: use 'default.<schema>.<table>' as the SQL prefix (not the database or connection id)\n",
+                        "  Column names are case-sensitive — wrap uppercase names in double quotes",
+                    ),
+                    result.id, result.id
+                )
+                .dark_grey()
+            );
         }
         _ => unreachable!(),
     }
@@ -614,8 +630,22 @@ pub fn tables_load(
 
     let full_name = format!("default.{}.{}", result.schema_name, result.table_name);
     println!("{}", "Table loaded".green());
-    println!("full_name: {}", full_name.green());
+    println!("full_name: {}", full_name.clone().green());
     println!("rows:      {}", result.row_count);
+    println!();
+    println!(
+        "{}",
+        format!(
+            concat!(
+                "Query it now:\n",
+                "  hotdata query \"SELECT * FROM {} LIMIT 10\"\n",
+                "\n  Tip: column names are case-sensitive.\n",
+                "  Wrap uppercase names in double quotes: SELECT \"MyColumn\" FROM {} LIMIT 10",
+            ),
+            full_name, full_name
+        )
+        .dark_grey()
+    );
 }
 
 pub fn tables_delete(workspace_id: &str, database: Option<&str>, table: &str, schema: Option<&str>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,7 @@ fn main() {
                 sql,
                 workspace_id,
                 connection,
+                database,
                 output,
                 command,
             } => {
@@ -268,7 +269,13 @@ fn main() {
                     Some(QueryCommands::Status { id }) => query::poll(&id, &workspace_id, &output),
                     None => match sql {
                         Some(sql) => {
-                            query::execute(&sql, &workspace_id, connection.as_deref(), &output)
+                            query::execute(
+                                &sql,
+                                &workspace_id,
+                                connection.as_deref(),
+                                database.as_deref(),
+                                &output,
+                            )
                         }
                         None => {
                             use clap::CommandFactory;
@@ -830,7 +837,7 @@ fn main() {
                     ),
                     _ => unreachable!(),
                 };
-                query::execute(&sql, &workspace_id, None, &output)
+                query::execute(&sql, &workspace_id, None, None, &output)
             }
             Commands::Queries {
                 id,

--- a/src/query.rs
+++ b/src/query.rs
@@ -45,8 +45,17 @@ fn value_to_string(v: &Value) -> String {
     }
 }
 
-pub fn execute(sql: &str, workspace_id: &str, connection: Option<&str>, format: &str) {
-    let api = ApiClient::new(Some(workspace_id));
+pub fn execute(
+    sql: &str,
+    workspace_id: &str,
+    connection: Option<&str>,
+    database: Option<&str>,
+    format: &str,
+) {
+    let mut api = ApiClient::new(Some(workspace_id));
+    if let Some(db_id) = database {
+        api = api.with_database(db_id);
+    }
 
     let mut body = serde_json::json!({
         "sql": sql,


### PR DESCRIPTION
## Summary

- Adds \`--database\` / \`-d\` flag to \`hotdata query\` so a managed database can be scoped per-query without running \`databases set\` first
- Adds \`ApiClient::with_database()\` builder method to override the \`X-Database-Id\` header for a single request without touching config
- After \`databases create\` (table output), prints a ready-to-run example with the correct \`databases load\` dot-notation syntax, the \`--database <id>\` flag, and the \`default.<schema>.<table>\` SQL prefix
- After \`databases load\`, prints a ready-to-run \`hotdata query\` command and a tip that uppercase column names require double-quoting

## Test plan

- [x] \`hotdata query --database <db_id> "SELECT * FROM default.public.<table> LIMIT 10"\` works without \`databases set\`
- [x] \`--database\` overrides a previously set current database
- [x] \`hotdata databases create\` table output shows correct \`databases load\` and \`query --database\` examples
- [x] \`hotdata databases load\` output shows correct \`hotdata query\` example with case-sensitivity tip
- [x] All existing unit tests pass (\`cargo test\`) — 165 pass; 3 pre-existing config env failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)