### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.2.9"
+version = "0.3.0"
 dependencies = [
  "anstyle",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.2.9"
+version = "0.3.0"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"


### PR DESCRIPTION
## v0.3.0 Release

### Features
- **Arrow IPC results** — query results now fetched as Arrow IPC instead of JSON rows; faster and type-faithful (integers stay integers, floats stay floats)
- **Async polling loop** — `hotdata query` now waits up to 5 minutes for slow queries instead of exiting with code 2; fetches result automatically when done
- **`--database` flag on `hotdata query`** — run queries against a specific managed database without `databases set`
- **`databases show`** — new subcommand to inspect a managed database by name or ID
- **`databases tables <db>`** — positional shorthand; `hotdata databases tables mydb` lists tables without needing the `list` subcommand
- **Background update notice** — update-available check runs concurrently with the command and prints after output (not before)
- **Skills auto-update on upgrade** — `hotdata update` now downloads and installs matching agent skills for the new binary version
- **Homebrew upgrade execution** — `hotdata update` on Homebrew installs now runs `brew upgrade` directly instead of just printing instructions

### Fixes
- Removed dead `AsyncResponse.status` field (was causing compiler warning)
- Reordered polling loop: poll first, then sleep — eliminates 500ms delay before first check
- Added 120s timeout to skills HTTP download client (was unlimited)
- Replaced chained `.unwrap()` with `.expect()` in tables help path

---
Merge this PR then tag `v0.3.0` on main to trigger the release.