### PR TITLE
chore: bump version to v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [0.3.2] - 2026-05-27
+
+### 🐛 Bug Fixes
+
+- *(datasets)* Add missing `-o`/`--output` flag to `datasets create`; move success banner to stderr so `-o json` stdout is `jq`-parseable (#110)
+- *(sandbox)* Move "Sandbox created" and "Sandbox updated" banners to stderr for clean `-o json` output (#110)
+- *(sandbox)* Fix missing trailing newline in `sandbox read` output (#110)
+- *(sandbox)* Add `sandbox delete <id>` subcommand; clears the active session automatically when the deleted sandbox was the active one (#110)
+- *(workspaces)* Fix incorrect lock check in `workspaces set` — was checking `HOTDATA_WORKSPACE` (always set in sandbox runs), now correctly checks `HOTDATA_SANDBOX` (#110)
+- *(context)* Surface a friendly hint when `context push` is blocked inside an active sandbox, pointing users to `hotdata sandbox set` (no args) to clear it (#110)
+
 ## [0.3.1] - 2026-05-25
 
 ### 🐛 Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,7 +1028,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hotdata-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anstyle",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
   Command line interface for <a href="https://www.hotdata.dev">Hotdata</a>.
   <br><br>
-  <img src="https://img.shields.io/badge/version-0.2.7-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.3.2-blue" alt="version">
   <a href="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml"><img src="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml/badge.svg" alt="build"></a>
   <a href="https://codecov.io/gh/hotdata-dev/hotdata-cli"><img src="https://codecov.io/gh/hotdata-dev/hotdata-cli/branch/main/graph/badge.svg" alt="coverage"></a>
 </p>

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-analytics
 description: Use this skill when the user wants OLAP-style SQL analytics in Hotdata — aggregations, GROUP BY, JOINs, reporting, exploratory queries, query run history, stored results, or materialized follow-up tables (Chain via datasets or managed databases). Activate for "analyze", "aggregate", "rollup", "pivot", "report", "metrics", "GROUP BY", "query history", "past queries", "query runs", "stored results", "materialize", "chain", "intermediate table", or sorted indexes for filters/range scans. Do not load for BM25/vector search or geospatial SQL — use hotdata-search or hotdata-geospatial. Requires the core hotdata skill for connections, tables, datasets, and auth.
-version: 0.3.1
+version: 0.3.2
 ---
 
 # Hotdata Analytics Skill

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.3.1
+version: 0.3.2
 ---
 
 # Hotdata Geospatial Skill

--- a/skills/hotdata-search/SKILL.md
+++ b/skills/hotdata-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-search
 description: Use this skill when the user wants full-text search, BM25 keyword search, vector similarity search, semantic search, embeddings, or retrieval indexes in Hotdata. Activate for "hotdata search", "BM25", "full-text", "vector search", "semantic search", "similarity", "embedding", "embedding provider", "create an index" (bm25 or vector), "list indexes" for search, or SQL using bm25_search or vector_distance. Do not load for general SQL analytics (aggregations, GROUP BY) or geospatial work — use hotdata-analytics or hotdata-geospatial instead. Requires the core hotdata skill for auth and workspace basics.
-version: 0.3.1
+version: 0.3.2
 ---
 
 # Hotdata Search Skill

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata
 description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, datasets, tables, basic SQL query, sandboxes, database context (context:DATAMODEL), jobs, and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "list datasets", "create a dataset", "execute a query", "list sandboxes", "database context", "context:DATAMODEL", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
-version: 0.3.1
+version: 0.3.2
 ---
 
 # Hotdata CLI Skill


### PR DESCRIPTION
## Summary

- Bump Cargo.toml version to 0.3.2
- Update Cargo.lock
- Add CHANGELOG entry for v0.3.2
- Bump all skill versions (hotdata, hotdata-search, hotdata-analytics, hotdata-geospatial) from 0.3.1 to 0.3.2

## What is in this release

All bug fixes from PR #110:

- **datasets create**: add missing -o/--output flag; banner moved to stderr so -o json is jq-parseable
- **sandbox new / update**: move success banners to stderr for clean -o json output
- **sandbox read**: fix missing trailing newline
- **sandbox delete**: new subcommand; auto-clears active session when the deleted sandbox was the active one
- **workspaces set**: fix incorrect lock check (HOTDATA_WORKSPACE to HOTDATA_SANDBOX)
- **context push**: friendly hint when blocked inside an active sandbox

## After merging

Tag v0.3.2 on the resulting merge commit to trigger the release workflow.