### PR TITLE
fix: handle pre-existing draft release in host job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,7 +276,14 @@ jobs:
           # Write and read notes from a file to avoid quoting breaking things
           echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          # The plan job runs `dist host --steps=create` which pre-creates the draft release.
+          # If the release already exists, edit it in place; otherwise create it fresh.
+          if gh release view "${{ needs.plan.outputs.tag }}" > /dev/null 2>&1; then
+            gh release edit "${{ needs.plan.outputs.tag }}" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt"
+            gh release upload "${{ needs.plan.outputs.tag }}" artifacts/* --clobber
+          else
+            gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          fi
 
   custom-publish-homebrew:
     needs:


### PR DESCRIPTION
## Problem

When a release tag is pushed, the plan job calls dist host --steps=create which pre-creates the GitHub release as a draft. Later, the host job calls dist host --steps=upload --steps=release (which uploads artifacts and publishes the draft), then tries to also run gh release create, which fails with: 'a release with the same tag name already exists'.

Because host fails at that step, the custom-publish-homebrew job is skipped and the Homebrew tap is never updated. This is what happened with v0.3.3.

## Fix

Replace the unconditional gh release create with a check: if the release already exists (the normal case), use gh release edit + gh release upload --clobber instead. If for some reason the release does not exist yet, fall back to gh release create as before.

## To recover v0.3.3

After merging, manually re-run the custom-publish-homebrew job from the failed v0.3.3 workflow run in Actions.