### PR TITLE
chore(ci): bump Node 20 actions to Node 24 runtime

### DIFF
--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.HOTDATA_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.HOTDATA_AUTOMATION_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps Node 20 GitHub Actions to their Node 24 runtime versions, pinned by SHA.

- actions/create-github-app-token: d72941d (v1) -> v3.2.0

Breaking changes to review:
- actions/create-github-app-token v1->v3: v2 made token repo-scoping explicit (token no longer grants access to all org repos by default; owner/repositories inputs now govern scope) and v3 bumped runtime to Node24. This workflow already sets owner and repositories, so scoping behavior is preserved.