### PR TITLE
chore: allow dirty ci in dist-workspace config

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,6 +7,8 @@ members = ["cargo:."]
 cargo-dist-version = "0.31.0"
 # CI backends to support
 ci = "github"
+# Allow the release workflow to be hand-customized without dist regenerating it
+allow-dirty = ["ci"]
 # The installers to generate for each app
 installers = ["shell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)


### PR DESCRIPTION
Sets `allow-dirty = ["ci"]` so `dist plan` stops flagging the hand-customized `release.yml` (the gh release create/edit dedup block) as out of date. Fixes the pre-existing failing `plan` check.