### PR TITLE
fix(databases): rename --description to --name in databases run

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -639,9 +639,9 @@ pub enum DatabasesCommands {
         #[arg(long)]
         database: Option<String>,
 
-        /// Description for the auto-created database (only used when --database is omitted)
+        /// Name for the auto-created database (only used when --database is omitted)
         #[arg(long)]
-        description: Option<String>,
+        name: Option<String>,
 
         /// Schema for tables declared in the auto-created database (default: public)
         #[arg(long, default_value = "public")]

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -453,13 +453,13 @@ pub fn get(workspace_id: &str, id_or_name: &str, format: &str) {
 /// the id instead of printing.
 fn create_and_return_id(
     api: &ApiClient,
-    description: Option<&str>,
+    name: Option<&str>,
     schema: &str,
     tables: &[String],
     expires_at: Option<&str>,
 ) -> String {
     use crossterm::style::Stylize;
-    let body = create_database_request(description, schema, tables, expires_at);
+    let body = create_database_request(name, schema, tables, expires_at);
     let (status, resp_body) = api.post_raw("/databases", &body);
     if !status.is_success() {
         eprintln!("{}", crate::util::api_error(resp_body).red());
@@ -493,7 +493,7 @@ fn mint_database_token(api: &ApiClient, database_id: &str) -> DatabaseTokenRespo
 pub fn run(
     database: Option<&str>,
     workspace_id: &str,
-    description: Option<&str>,
+    name: Option<&str>,
     schema: &str,
     tables: &[String],
     expires_at: Option<&str>,
@@ -509,7 +509,7 @@ pub fn run(
     // for the child process, addressed only by the token we mint below.
     let database_id = match database {
         Some(id) => id.to_string(),
-        None => create_and_return_id(&api, description, schema, tables, expires_at),
+        None => create_and_return_id(&api, name, schema, tables, expires_at),
     };
 
     let resp = mint_database_token(&api, &database_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,7 @@ fn main() {
                 // group-level name_or_id is treated as a `show` shorthand.
                 if let Some(DatabasesCommands::Run {
                     database,
-                    description,
+                    name,
                     schema,
                     tables,
                     expires_at,
@@ -414,7 +414,7 @@ fn main() {
                     databases::run(
                         db,
                         &workspace_id,
-                        description.as_deref(),
+                        name.as_deref(),
                         &schema,
                         &tables,
                         expires_at.as_deref(),


### PR DESCRIPTION
## Summary
- Renames `--description` to `--name` in `databases run` to be consistent with `databases create`, which already uses `--name` for the catalog alias
- Updates the field name through `command.rs`, `main.rs`, and `databases.rs` (`run` and `create_and_return_id`)

## Test plan
- [ ] `hotdata databases run --name my-db -- <cmd>` creates a named auto-database and runs the command
- [ ] `hotdata databases run --database <id> -- <cmd>` still works (unaffected path)
- [ ] `hotdata databases create --name my-db` still works (unchanged)