### PR TITLE
feat(query): remove dead --connection flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,12 +216,12 @@ hotdata context push <name> [-w <id>] [--dry-run]
 ## Query
 
 ```sh
-hotdata query "<sql>" [-w <id>] [--connection <connection_id>] [-o table|json|csv]
+hotdata query "<sql>" [-w <id>] [-d <database>] [-o table|json|csv]
 hotdata query status <query_run_id> [-o table|json|csv]
 ```
 
 - Default output is `table`, which prints results with row count and execution time.
-- Use `--connection` to scope the query to a specific connection.
+- Use `-d`/`--database` to run the query against a specific managed database.
 - Long-running queries automatically fall back to async execution and return a `query_run_id`.
 - Use `hotdata query status <query_run_id>` to poll for results.
 - Exit codes for `query status`: `0` = succeeded, `1` = failed, `2` = still running (poll again).

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -17,7 +17,7 @@ version: 0.4.0
 ## Execute SQL
 
 ```bash
-hotdata query "<sql>" [--workspace-id <workspace_id>] [--connection <connection_id>] [--output table|json|csv]
+hotdata query "<sql>" [--workspace-id <workspace_id>] [--database <database>] [--output table|json|csv]
 hotdata query status <query_run_id> [--output table|json|csv]
 ```
 

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -315,7 +315,7 @@ hotdata context push <name> [--database-id <id>] [--dry-run]
 ### Execute SQL Query
 
 ```
-hotdata query "<sql>" [--workspace-id <workspace_id>] [--connection <connection_id>] [--output table|json|csv]
+hotdata query "<sql>" [--workspace-id <workspace_id>] [--database <database>] [--output table|json|csv]
 hotdata query status <query_run_id> [--output table|json|csv]
 ```
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -34,10 +34,6 @@ pub enum Commands {
         #[arg(long, short = 'w')]
         workspace_id: Option<String>,
 
-        /// Scope query to a specific connection
-        #[arg(long)]
-        connection: Option<String>,
-
         /// Run query against a specific managed database (overrides the current database set via `databases set`)
         #[arg(long, short = 'd')]
         database: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,6 @@ fn main() {
             Commands::Query {
                 sql,
                 workspace_id,
-                connection,
                 database,
                 output,
                 command,
@@ -283,13 +282,9 @@ fn main() {
                 match command {
                     Some(QueryCommands::Status { id }) => query::poll(&id, &workspace_id, &output),
                     None => match sql {
-                        Some(sql) => query::execute(
-                            &sql,
-                            &workspace_id,
-                            connection.as_deref(),
-                            database.as_deref(),
-                            &output,
-                        ),
+                        Some(sql) => {
+                            query::execute(&sql, &workspace_id, database.as_deref(), &output)
+                        }
                         None => {
                             use clap::CommandFactory;
                             let mut cmd = Cli::command();
@@ -912,7 +907,7 @@ fn main() {
                     ),
                     _ => unreachable!(),
                 };
-                query::execute(&sql, &workspace_id, None, None, &output)
+                query::execute(&sql, &workspace_id, None, &output)
             }
             Commands::Queries {
                 id,

--- a/src/query.rs
+++ b/src/query.rs
@@ -230,19 +230,8 @@ pub(crate) fn fetch_arrow_result(api: &Api, result_id: &str) -> QueryResponse {
     arrow_ipc_to_query_response(bytes, result_id.to_owned())
 }
 
-pub fn execute(
-    sql: &str,
-    workspace_id: &str,
-    connection: Option<&str>,
-    database: Option<&str>,
-    format: &str,
-) {
+pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &str) {
     let api = Api::new(Some(workspace_id));
-
-    // `--connection` is a no-op: /query is database-scoped and the endpoint has
-    // no connection_id field. Accepted for compatibility (see follow-up issue
-    // to remove it).
-    let _ = connection;
 
     // Scope to the explicit --database flag, else the active database resolved
     // at construction (HOTDATA_DATABASE / current database). submit_query sends


### PR DESCRIPTION
Removes the `query --connection` flag, a confirmed no-op since the SDK refactor stopped sending the ignored `connection_id` field. Docs updated to point to `-d/--database`.

Closes #132