### PR TITLE
chore(deps): use published hotdata 0.1.1 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,8 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.1.0"
-source = "git+https://github.com/hotdata-dev/sdk-rust?rev=1687ba2ffb8f816540d00d7c1fdfe165a8fbd150#1687ba2ffb8f816540d00d7c1fdfe165a8fbd150"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96620c427754f23659e79a45b4ae3e9d25e927e476e68af60683f46e460491cc"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,9 @@ path = "src/main.rs"
 [dependencies]
 # Hotdata Rust SDK. The CLI's sync wrapper (src/sdk.rs) drives this async SDK
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
-# decode; the pinned rev is the first to carry `content_length` on the streaming
-# `upload_stream` (sized body, not chunked, so the server can fast-fail an
-# oversized upload — see src/sdk.rs::Api::upload_stream).
-hotdata = { git = "https://github.com/hotdata-dev/sdk-rust", rev = "1687ba2ffb8f816540d00d7c1fdfe165a8fbd150", features = ["arrow"] }
+# decode; `upload_stream` carries `content_length` (sized body, not chunked, so
+# the server can fast-fail an oversized upload — see src/sdk.rs::Api::upload_stream).
+hotdata = { version = "0.1.1", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). `sync` backs the
 # mpsc channel that bridges the blocking upload reader into an async byte stream.


### PR DESCRIPTION
Switches the SDK dependency from a git rev to the published `hotdata` 0.1.1 crate on crates.io. The published tag is a no-API-change descendant of the old pinned rev, so the `upload_stream` content_length feature is intact; full suite green.