### PR TITLE
fix(ci): skip scenario-parity for Dependabot PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,10 @@ jobs:
   # doesn't cover them, e.g. datasets/secrets/saved-queries).
   scenario-parity:
     runs-on: ubuntu-latest
+    # Dependabot PRs run with only Dependabot secrets, so the GitHub App
+    # credentials needed to fetch the private scenarios manifest are absent.
+    # A dependency bump can't change scenario/test-file parity anyway, so skip.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
Dependabot PRs run with only Dependabot secrets, so `scenario-parity` can't generate the GitHub App token it needs to fetch the private test-scenarios manifest and fails. A dependency bump can't change scenario/test-file parity, so skip the job for `dependabot[bot]` (same pattern the Claude review workflow uses).