### PR TITLE
chore: Release hotdata-cli version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🚀 Features
 
 - Follow truncated inline query results to full set
+- Auto-retry queries shed under load (HTTP 429 `OVERLOADED`), honoring `Retry-After`
 
 ### 🐛 Bug Fixes
 
@@ -10,7 +11,7 @@
 
 ### 💼 Other
 
-- Bump hotdata SDK to 0.3.0
+- Bump hotdata SDK to 0.3.1
 ## [0.4.2] - 2026-06-15
 
 ### 📚 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💼 Other
 
 - Bump hotdata SDK to 0.3.1
+
 ## [0.4.2] - 2026-06-15
 
 ### 📚 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.5.0] - 2026-06-16
+
+### 🐛 Bug Fixes
+
+- Follow truncated inline query results to full set
+- Preserve inline warning and timing when following truncation
+
+### 💼 Other
+
+- Bump hotdata SDK to 0.2.0
 ## [0.4.2] - 2026-06-15
 
 ### 📚 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### 🐛 Bug Fixes
 
 - Preserve inline warning and timing when following truncation
+- Stop using deprecated `QueryResponse.row_count`
 
 ### 💼 Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💼 Other
 
-- Bump hotdata SDK to 0.2.0
+- Bump hotdata SDK to 0.3.0
 ## [0.4.2] - 2026-06-15
 
 ### 📚 Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## [0.5.0] - 2026-06-16
 
-### 🐛 Bug Fixes
+### 🚀 Features
 
 - Follow truncated inline query results to full set
+
+### 🐛 Bug Fixes
+
 - Preserve inline warning and timing when following truncation
 
 ### 💼 Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e42225ce51283f0dc70c4162e5499aef1afdf13dac3ee3cd143bd31c5bcb524"
+checksum = "c54b66bbff35134c3c592aa55694015d282a1cbcdb549eaca6742b3ba35c12f1"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "hotdata-cli"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
 # decode; `upload_stream` carries `content_length` (sized body, not chunked, so
 # the server can fast-fail an oversized upload — see src/sdk.rs::Api::upload_stream).
-hotdata = { version = "0.3.0", features = ["arrow"] }
+hotdata = { version = "0.3.1", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). `sync` backs the
 # mpsc channel that bridges the blocking upload reader into an async byte stream.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.4.2"
+version = "0.5.0"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
   Command line interface for <a href="https://www.hotdata.dev">Hotdata</a>.
   <br><br>
-  <img src="https://img.shields.io/badge/version-0.4.2-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.5.0-blue" alt="version">
   <a href="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml"><img src="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml/badge.svg" alt="build"></a>
   <a href="https://codecov.io/gh/hotdata-dev/hotdata-cli"><img src="https://codecov.io/gh/hotdata-dev/hotdata-cli/branch/main/graph/badge.svg" alt="coverage"></a>
 </p>

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-analytics
 description: Use this skill when the user wants OLAP-style SQL analytics in Hotdata — aggregations, GROUP BY, JOINs, reporting, exploratory queries, query run history, stored results, or materialized follow-up tables (Chain via datasets or managed databases). Activate for "analyze", "aggregate", "rollup", "pivot", "report", "metrics", "GROUP BY", "query history", "past queries", "query runs", "stored results", "materialize", "chain", "intermediate table", or sorted indexes for filters/range scans. Do not load for BM25/vector search or geospatial SQL — use hotdata-search or hotdata-geospatial. Requires the core hotdata skill for connections, tables, datasets, and auth.
-version: 0.4.2
+version: 0.5.0
 ---
 
 # Hotdata Analytics Skill

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.4.2
+version: 0.5.0
 ---
 
 # Hotdata Geospatial Skill

--- a/skills/hotdata-search/SKILL.md
+++ b/skills/hotdata-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-search
 description: Use this skill when the user wants full-text search, BM25 keyword search, vector similarity search, semantic search, embeddings, or retrieval indexes in Hotdata. Activate for "hotdata search", "BM25", "full-text", "vector search", "semantic search", "similarity", "embedding", "embedding provider", "create an index" (bm25 or vector), "list indexes" for search, or SQL using bm25_search or vector_distance. Do not load for general SQL analytics (aggregations, GROUP BY) or geospatial work — use hotdata-analytics or hotdata-geospatial instead. Requires the core hotdata skill for auth and workspace basics.
-version: 0.4.2
+version: 0.5.0
 ---
 
 # Hotdata Search Skill

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -323,6 +323,8 @@ hotdata query status <query_run_id> [--output table|json|csv]
 - Use `hotdata tables list` for discovery — not `information_schema` via `query`.
 - **PostgreSQL dialect.** Quote non-lowercase columns with double quotes.
 - Async runs return `query_run_id` → poll with `query status` (do not re-run the same heavy SQL).
+- **Large results are complete, not a preview.** The server returns inline rows only up to a bounded cap and persists the full set out-of-band; `hotdata query` transparently fetches the full result, so the printed rows and row count are the complete set. (If the full result can't be retrieved, the CLI prints the preview and a `warning:` to stderr.)
+- **Backpressure is handled.** Under heavy concurrent load the server may shed a query with HTTP 429 (`OVERLOADED`); the CLI auto-retries (honoring `Retry-After`) before surfacing an error — no manual retry needed.
 - **OLAP** (aggregations, history, Chain, sorted indexes): **`hotdata-analytics`** skill.
 - **Search** (BM25, vector): **`hotdata-search`** skill.
 

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata
 description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, datasets, tables, basic SQL query, database context (context:DATAMODEL), jobs, and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "list datasets", "create a dataset", "execute a query", "database context", "context:DATAMODEL", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
-version: 0.4.2
+version: 0.5.0
 ---
 
 # Hotdata CLI Skill


### PR DESCRIPTION
Release hotdata-cli 0.5.0. Ships query truncation auto-follow and HTTP 429/`OVERLOADED` auto-retry (via hotdata SDK 0.3.1), drops the deprecated `row_count`, and updates the changelog and `hotdata` skill query docs to match.