### PR TITLE
feat: auto-retry on server overload via hotdata SDK 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ba716cff96f209c53979615cac927933b43ce3d905ede86efadee28990b8db"
+checksum = "1e42225ce51283f0dc70c4162e5499aef1afdf13dac3ee3cd143bd31c5bcb524"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
 # decode; `upload_stream` carries `content_length` (sized body, not chunked, so
 # the server can fast-fail an oversized upload — see src/sdk.rs::Api::upload_stream).
-hotdata = { version = "0.2.0", features = ["arrow"] }
+hotdata = { version = "0.3.0", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). `sync` backs the
 # mpsc channel that bridges the blocking upload reader into an async byte stream.


### PR DESCRIPTION
Bumps the hotdata Rust SDK to 0.3.0, whose generated operations now transparently retry HTTP 429 (OVERLOADED) admission shedding — honoring `Retry-After` with backoff — so CLI commands ride out transient server overload instead of failing.

Builds clean, all tests pass, and core paths (query/Arrow decode, results, listings) were smoke-tested against production.