### PR TITLE
chore(deps): upgrade hotdata SDK 0.3.1 -> 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b66bbff35134c3c592aa55694015d282a1cbcdb549eaca6742b3ba35c12f1"
+checksum = "a79ce05333e09411029842117c625b5350d939697a450b7b6e4cc7251b87c28b"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
 # decode; `upload_stream` carries `content_length` (sized body, not chunked, so
 # the server can fast-fail an oversized upload — see src/sdk.rs::Api::upload_stream).
-hotdata = { version = "0.3.1", features = ["arrow"] }
+hotdata = { version = "0.4.0", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). `sync` backs the
 # mpsc channel that bridges the blocking upload reader into an async byte stream.


### PR DESCRIPTION
## Summary

Upgrades the `hotdata` Rust SDK pin from **0.3.1 → 0.4.0**.

## What changed in 0.4.0

- **Removed** the `datasets` API and all dataset models (breaking).
- **Added** a `usage` API + `workspace_usage_response` model.

The CLI already removed its datasets surface in #166, so the SDK's datasets removal is a no-op here, and the new usage API is currently unused. **No source changes were required** — only the `Cargo.toml` pin and `Cargo.lock`.

## Verification

- `cargo build` / `cargo clippy --all-targets` clean (no new warnings).
- Full test suite green (206 passed).
- No lingering SDK dataset references in `src/`.
- Production smoke test (workspace **AgentRyan**):
  - `auth status` ✅
  - `databases list` → 25 databases ✅
  - `query "SELECT 1 AS ok, 'hello' AS msg"` → renders via the arrow decode path ✅
