### PR TITLE
fix(databases): surface the id change when load recreates a managed database

### DIFF
--- a/skills/hotdata/references/WORKFLOWS.md
+++ b/skills/hotdata/references/WORKFLOWS.md
@@ -106,6 +106,8 @@ End-to-end checklists. Use the linked sections for command detail and guardrails
    hotdata databases load --catalog sales --table customers --url https://example.com/customers.parquet
    ```
 
+   > Auto-declaring a *new* table recreates the database (no add-table API), which **changes its `id`**. Always reference a managed database by its **catalog** (stable), not the `id` returned by `databases create` — that id goes stale after the next `load` of an undeclared table. Declare tables up front (`databases create --table orders --table customers`) to avoid the recreate.
+
 3. Confirm and query:
 
    ```bash

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -1013,6 +1013,29 @@ pub fn tables_load(
             }
         };
         let _ = crate::config::save_current_database("default", workspace_id, &new_db.id);
+        // Managed databases have no add-table endpoint, so declaring a new table
+        // is a delete + recreate — which mints a NEW database id. Surface that
+        // explicitly: the id printed by `databases create` is now stale, and
+        // id-based automation (e.g. `databases delete <create-time-id>`) would
+        // otherwise fail with "no database with id". Reference by catalog instead.
+        {
+            use crossterm::style::Stylize;
+            let catalog = db
+                .default_catalog
+                .as_deref()
+                .or(db.name.as_deref())
+                .unwrap_or(&db.id);
+            eprintln!(
+                "{}",
+                format!(
+                    "note: table '{table}' was not declared — recreated database '{catalog}' to add it \
+                     (id {} → {}). Managed databases are recreated when a new table is loaded; \
+                     reference them by catalog ('{catalog}'), not the create-time id.",
+                    db.id, new_db.id
+                )
+                .yellow()
+            );
+        }
         let new_path = managed_table_load_path(&new_db.default_connection_id, schema, table);
         let spinner = crate::util::spinner("Loading table...");
         let result = api.post_raw(&new_path, &body).unwrap_or_else(|e| {


### PR DESCRIPTION
## Summary

Loading an **undeclared** table into a managed database triggers an auto-declare path that **delete + recreates** the database (managed DBs have no add-table endpoint) — which mints a **new database id**. This was silent unless existing tables had synced data, so:

- the id printed by `databases create` goes stale after the next `load` of a new table, and
- `databases delete <create-time-id>` then fails with *"no database with id"*.

I hit this directly while testing: `databases create --catalog X` printed one id, but after `databases load` the database was listed under a different id, and delete-by-printed-id failed.

## Root cause

`databases create` is **correct** — its returned id matches `databases list` immediately (verified). The id only changes inside `tables_load`'s recreate path (`src/databases.rs`), and that change was never surfaced when there was no synced data to warn about.

## Fix

- Emit a clear note when `load` recreates the database, showing `id <old> → <new>` and pointing users to reference managed databases by **catalog** (stable), not the create-time id.
- Document the same in the managed-database workflow (`references/WORKFLOWS.md`): auto-declaring a new table recreates the DB and changes its id; reference by catalog, or declare tables up front with `databases create --table …`.

No server change needed; this is a transparency fix for an inherent consequence of the recreate workaround.

## Verification (production)

```
$ hotdata databases create --catalog probe_notice      # id A
$ hotdata databases load --catalog probe_notice --table t --file probe.parquet
note: table 't' was not declared — recreated database 'probe_notice' to add it
(id dbidybn82eo… → dbidsqfb9xo…). … reference them by catalog ('probe_notice'),
not the create-time id.
$ hotdata databases delete probe_notice                 # delete by catalog works
Database deleted.
```

`cargo build`/`clippy`/`fmt` clean; `databases` test suite green (23 passed).
