### PR TITLE
feat(databases): attach connection catalogs for cross-source queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ hotdata databases delete <name_or_id>
 hotdata databases run [--database <id>] [--name <label>] [--schema public] [--table <table> ...] [--expires-at <duration|timestamp>] <cmd> [args...]
 hotdata databases <id> run <cmd> [args...]
 
+# Attach a connection as a queryable catalog (enables cross-source queries)
+hotdata databases attach <connection_id|name> [--database <id>] [--alias <alias>]
+hotdata databases detach <connection_id|name|alias> [--database <id>]
+
 # Preferred: load by catalog alias (auto-declares table if needed)
 hotdata databases load --catalog <alias> --table <table> [--schema public] (--file <path> | --url <url> | --upload-id <id>)
 
@@ -154,6 +158,7 @@ hotdata databases tables delete <table> [--database <id_or_name>] [--schema publ
 - `load` (top-level shorthand) — loads a parquet file into `--catalog.--schema.--table`. If the table was not declared at create time, the CLI automatically deletes and recreates the database with the table declared, then retries the load.
 - `tables load` uploads a **parquet** file (or uses a staged `upload_id` from `POST /v1/files`) and publishes it as the table generation (`replace` mode).
 - `run` mints a database-scoped JWT and execs `<cmd>` with `HOTDATA_DATABASE_TOKEN`, `HOTDATA_DATABASE_REFRESH_TOKEN`, `HOTDATA_DATABASE`, `HOTDATA_WORKSPACE`, and `HOTDATA_API_URL` injected into its environment.
+- `attach` / `detach` — a query runs inside one managed database, whose scope sees its own catalog plus **attached** connection catalogs only. Attach a connection to make its **live** tables queryable there and to join across sources in one query; `--alias` sets the SQL name (defaults to the connection's name). `create --attach <connection>[=<alias>]` attaches at creation. Don't export a connection to parquet just to query it — attach is the live, sync-preserving path.
 - Managed table loads accept **parquet** only — convert CSV/JSON to parquet first.
 
 Example:

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -24,6 +24,7 @@ hotdata query status <query_run_id>
 - **PostgreSQL dialect.** Quote mixed-case identifiers: `"CustomerName"`.
 - Use **`hotdata tables list`** for schema discovery — not `information_schema` via `query`.
 - Fully qualified names: `<connection>.<schema>.<table>`, `<database>.<schema>.<table>`.
+- **Query scope:** every query runs inside one managed database (active or `--database`); it sees that database's own catalog plus **attached** connection catalogs only. To query a connection table, or **join a managed table against a connection table**, attach the connection first: `hotdata databases attach <connection>` — see **`hotdata`** skill → [Querying across connections](../hotdata/SKILL.md). No managed database set → *"a database is required."*
 - Long-running queries may return `query_run_id` → poll with **`query status`** (exit `2` = still running). Do not re-run identical heavy SQL while polling.
 - For **workspace-wide** joins and naming, load **context:DATAMODEL** when listed (`hotdata context list` → `show DATAMODEL`) — see **`hotdata`** skill.
 
@@ -32,7 +33,7 @@ hotdata query status <query_run_id>
 Typical analytics SQL (all via `hotdata query`):
 
 - **Aggregations:** `COUNT`, `SUM`, `AVG`, `MIN`, `MAX` with `GROUP BY`
-- **Joins:** `INNER` / `LEFT JOIN` across `<connection>.<schema>.<table>` names
+- **Joins:** `INNER` / `LEFT JOIN` across `<catalog>.<schema>.<table>` names — every referenced catalog (managed or connection) must be in the active database's scope; attach connections first (`hotdata databases attach`)
 - **Filtering:** `WHERE` on partition-friendly columns (consider **sorted** indexes below)
 - **Ordering:** `ORDER BY` on metrics or dimensions
 - **Bounded exploration:** always `LIMIT` while iterating; widen once validated

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -177,6 +177,10 @@ hotdata databases delete <id_or_name> [--workspace-id <workspace_id>]
 hotdata databases run [--database <id>] [--name <label>] [--schema public] [--table <table> ...] [--expires-at <duration|timestamp>] [--workspace-id <workspace_id>] <cmd> [args...]
 hotdata databases <id> run <cmd> [args...]
 
+# Attach a connection as a queryable catalog (enables cross-source queries — see below)
+hotdata databases attach <connection_id|name> [--database <id>] [--alias <alias>]
+hotdata databases detach <connection_id|name|alias> [--database <id>]
+
 # Preferred: load by catalog alias (auto-declares table if needed)
 hotdata databases load --catalog <alias> --table <table> [--schema public] (--file <path> | --url <url> | --upload-id <id>) [--workspace-id <workspace_id>]
 
@@ -197,6 +201,9 @@ hotdata databases tables delete <table> [--database <id_or_name>] [--schema publ
 - `tables load` — uploads a local parquet file (`--file`), a remote parquet URL (`--url`), or a pre-staged upload (`--upload-id`) and publishes with **replace** mode.
 - `tables delete` — drops a table from the managed database.
 - `run` — mints a database-scoped JWT (via `POST /v1/auth/database`) and execs `<cmd>` with `HOTDATA_DATABASE_TOKEN`, `HOTDATA_DATABASE_REFRESH_TOKEN`, `HOTDATA_DATABASE`, `HOTDATA_WORKSPACE`, and `HOTDATA_API_URL` injected. Pass a database id as a group positional (`hotdata databases <id> run ...`) or via `--database <id>`; omit both to auto-create a scratch database using `--name` / `--schema` / `--table` / `--expires-at`. Use this to launch an agent or child process whose API access is scoped to a single database. The minted JWT carries `database`, `workspaces`, `permissions:["read","write"]`, `source:"database_token"`. The session is persisted at `~/.hotdata/database_session.json` (mode `0600`); the child's exit code is propagated.
+- `attach` — attaches a **connection** as a queryable catalog on a managed database, so the connection's **live** tables become visible inside that database's query scope. Defaults to the active database; target another with `--database`. `--alias` sets the SQL name the catalog answers to (defaults to the connection's name). This is how you query connection tables and **join across sources** — see [Querying across connections](#querying-across-connections-attach).
+- `detach` — removes an attached connection catalog. Accepts the connection name/id **or** the alias you attached it under. Defaults to the active database.
+- `create --attach <connection>[=<alias>]` — attach one or more connections at creation time (repeatable), e.g. `--attach github --attach salesdb=sales`.
 
 Example:
 
@@ -206,6 +213,31 @@ hotdata databases load --catalog airbnb --table listings --url https://example.c
 hotdata query "SELECT count(*) FROM airbnb.public.listings"
 ```
 
+#### Querying across connections (attach)
+
+**A `hotdata query` runs inside exactly one managed database** — the active database (`hotdata databases set <id>`) or the one named by `--database`. With none set, the query fails with *"a database is required."* That database's query scope sees **only its own catalog plus any connection catalogs explicitly attached to it** — a workspace connection is **not** visible just because it exists. Referencing an unattached connection fails with *"table '\<catalog\>.\<schema\>.\<table\>' not found."*
+
+To query a connection's tables, or **join a managed table against a connection table in one query**, attach the connection to the database first. The connection's data stays **live** (synced) — this is not a copy:
+
+```
+# Attach the 'github' connection (live) to the active database under alias 'gh'
+hotdata databases attach github --alias gh
+
+# Now both the database's own tables and the attached connection are in scope:
+hotdata query "SELECT * FROM gh.github.issues WHERE state = 'OPEN' LIMIT 10"
+
+# Cross-source join: a managed table JOINed against the live connection table
+hotdata query "
+  SELECT t.id, i.title
+  FROM mycatalog.public.tickets t
+  JOIN gh.github.issues i ON i.number = t.gh_issue
+"
+
+hotdata databases detach gh   # when finished (optional)
+```
+
+Without `--alias`, the catalog answers to the connection's own name (`github.github.issues`). Do **not** export a connection to parquet just to query it — attach is the live, sync-preserving path.
+
 ### List Tables and Columns
 ```
 hotdata tables list [--workspace-id <workspace_id>] [--connection-id <connection_id>] [--schema <pattern>] [--table <pattern>] [--limit <int>] [--cursor <cursor>] [--output table|json|yaml]
@@ -214,7 +246,7 @@ hotdata tables list [--workspace-id <workspace_id>] [--connection-id <connection
 - **Always use this command to inspect available tables and columns.** Do NOT use the `query` command to query `information_schema` for this purpose.
 - Without `--connection-id`: lists all tables with `table`, `synced`, `last_sync`. The `table` column is formatted as `<connection>.<schema>.<table>`.
 - With `--connection-id`: includes column definitions. Lists each column as its own row with `table`, `column`, `data_type`, `nullable`. Use this to inspect the schema before writing queries.
-- **Always use the full `<connection>.<schema>.<table>` name when referencing tables in SQL queries.**
+- **Always use the full `<connection>.<schema>.<table>` name when referencing tables in SQL queries.** A connection table is only queryable once its connection is attached to the active database (`hotdata databases attach <connection>`); see [Querying across connections (attach)](#querying-across-connections-attach).
 - `--schema` and `--table` support SQL `%` wildcard patterns (e.g. `--table order%` matches `orders`, `order_items`, etc.).
 - Results are paginated (default 100 per page). If more results are available, a `--cursor` token is printed — pass it to fetch the next page.
 
@@ -244,7 +276,8 @@ hotdata query status <query_run_id>
 ```
 
 - Default output is `table` (row count and execution time).
-- Use `hotdata tables list` for discovery — not `information_schema` via `query`.
+- **A query runs inside one managed database** (active database or `--database`); with none set it fails *"a database is required."* The scope sees the database's own catalog **plus any attached connection catalogs only**. To query a connection's tables or join across sources, attach the connection first — see [Querying across connections (attach)](#querying-across-connections-attach).
+- Use `hotdata tables list` for discovery — not `information_schema` via `query`. (Discovery lists every workspace table; queryability still requires the table's catalog to be in the active database's scope.)
 - **PostgreSQL dialect.** Quote non-lowercase columns with double quotes.
 - Async runs return `query_run_id` → poll with `query status` (do not re-run the same heavy SQL).
 - **Large results are complete, not a preview.** The server returns inline rows only up to a bounded cap and persists the full set out-of-band; `hotdata query` transparently fetches the full result, so the printed rows and row count are the complete set. (If the full result can't be retrieved, the CLI prints the preview and a `warning:` to stderr.)

--- a/skills/hotdata/references/DATA_MODEL.template.md
+++ b/skills/hotdata/references/DATA_MODEL.template.md
@@ -52,6 +52,8 @@ For each business entity:
 
 Document safe join paths and caveats (fan-out, timing, different refresh cadence, type mismatches).
 
+> A cross-connection join runs inside one managed database; each connection it touches must be **attached** to that database (`hotdata databases attach <connection>`) so its live tables are in query scope. Note here which connections a join requires attached, and the alias each is attached under. See **`hotdata`** skill → Querying across connections.
+
 ## Search & index summary (optional)
 
 | Table | Column | Kind (vector / text / …) | Index status | Notes |

--- a/skills/hotdata/references/WORKFLOWS.md
+++ b/skills/hotdata/references/WORKFLOWS.md
@@ -74,6 +74,21 @@ End-to-end checklists. Use the linked sections for command detail and guardrails
 
 **Detail:** [hotdata-search INDEXES.md](../../hotdata-search/references/INDEXES.md)
 
+### Cross-source query (attach a connection)
+
+**Skill:** **`hotdata`**
+
+A `hotdata query` runs inside **one** managed database; its scope sees that database's own catalog plus **attached** connection catalogs only. To query a connection's tables — or join a managed table against a live connection table in one query — attach the connection. (No managed database set → *"a database is required."*; an unattached catalog → *"table not found."*)
+
+1. [ ] Pick/create the managed database that will be the query context (`hotdata databases set <id>` or `databases create --catalog <alias>`)
+2. [ ] Attach the connection(s) you need (live, sync intact): `hotdata databases attach <connection> [--alias <a>]`
+   - Or attach at creation: `hotdata databases create --catalog <alias> --attach <connection>[=<alias>]`
+3. [ ] Confirm scope: `hotdata databases <id>` lists attached catalogs
+4. [ ] Query across sources: `hotdata query "SELECT … FROM <my_catalog>.public.<t> JOIN <connection_or_alias>.<schema>.<table> ON …"`
+5. [ ] (Optional) `hotdata databases detach <connection|alias>` when finished; record required attachments in **context:DATAMODEL → Cross-connection joins**
+
+**Do not** export a connection to parquet just to query it — attach is the live, sync-preserving path.
+
 ---
 
 ## Managed databases

--- a/src/command.rs
+++ b/src/command.rs
@@ -481,9 +481,45 @@ pub enum DatabasesCommands {
         #[arg(long)]
         expires_at: Option<String>,
 
+        /// Attach a connection as a queryable catalog on the new database (repeatable).
+        /// Accepts a connection name or id, optionally `connection=alias` to set the
+        /// SQL alias it answers to: `--attach github --attach salesdb=sales`.
+        #[arg(long = "attach")]
+        attach: Vec<String>,
+
         /// Output format
         #[arg(long = "output", short = 'o', default_value = "table", value_parser = ["table", "json", "yaml"])]
         output: String,
+    },
+
+    /// Attach a connection as a queryable catalog on a managed database.
+    ///
+    /// A `query` runs inside one managed database; attaching a connection makes
+    /// its live tables visible in that database's scope, so you can join across
+    /// sources in a single query without exporting data. Reachable in SQL as
+    /// `<alias>.<schema>.<table>`, or `<connection-name>.<schema>.<table>` when
+    /// `--alias` is omitted.
+    Attach {
+        /// Connection name or id to attach (e.g. `github`)
+        connection: String,
+
+        /// Database id, catalog, or name to attach into (defaults to the current database)
+        #[arg(long, short = 'd')]
+        database: Option<String>,
+
+        /// Alias the catalog answers to in SQL. Defaults to the connection's name.
+        #[arg(long)]
+        alias: Option<String>,
+    },
+
+    /// Detach a previously attached connection catalog from a managed database.
+    Detach {
+        /// Connection name or id to detach
+        connection: String,
+
+        /// Database id, catalog, or name to detach from (defaults to the current database)
+        #[arg(long, short = 'd')]
+        database: Option<String>,
     },
 
     /// Set the current database (used by default when no database is specified)

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -197,14 +197,20 @@ struct ListResponse {
     connections: Vec<Connection>,
 }
 
-/// Resolve a connection name or ID to a connection ID, exiting on failure.
+/// Resolve a connection name or ID to a connection ID, returning `Err(message)`
+/// when nothing matches.
 ///
 /// If `name_or_id` looks like a raw connection ID (starts with "conn"), tries
 /// `GET /connections/{id}` directly first to avoid listing the full workspace.
-/// Falls back to listing and matching by name on a 404 or when given a plain name.
-pub fn resolve_connection_id(api: &Api, name_or_id: &str) -> String {
-    use crossterm::style::Stylize;
-
+/// Falls back to listing and matching by name, then to managed-database catalog
+/// aliases. Only the "no match" outcome is an `Err`; a transport/API failure
+/// during resolution still exits (the API is unreachable — not "this name is
+/// wrong"), preserving the auth-aware error from [`ApiError::exit`].
+///
+/// [`resolve_connection_id`] is the exiting wrapper for callers with no recovery
+/// path; the `Result` form lets `databases create --attach` warn on a bad name
+/// and continue to the next attachment instead of aborting mid-loop.
+pub fn try_resolve_connection_id(api: &Api, name_or_id: &str) -> Result<String, String> {
     if name_or_id.starts_with("conn") {
         // Existence probe: a 404 just means "not a raw id", fall through to the
         // name/catalog lookup; any other error is fatal.
@@ -212,7 +218,7 @@ pub fn resolve_connection_id(api: &Api, name_or_id: &str) -> String {
             .unwrap_or_else(|e| e.exit())
             .is_some()
         {
-            return name_or_id.to_string();
+            return Ok(name_or_id.to_string());
         }
     }
 
@@ -225,7 +231,7 @@ pub fn resolve_connection_id(api: &Api, name_or_id: &str) -> String {
         && (active_db.default_catalog.as_deref() == Some(name_or_id)
             || active_db.name.as_deref() == Some(name_or_id))
     {
-        return active_db.default_connection_id;
+        return Ok(active_db.default_connection_id);
     }
 
     let resp = block(api.client().connections().list()).unwrap_or_else(|e| e.exit());
@@ -234,19 +240,28 @@ pub fn resolve_connection_id(api: &Api, name_or_id: &str) -> String {
         .iter()
         .find(|c| c.id == name_or_id || c.name == name_or_id)
     {
-        return conn.id.clone();
+        return Ok(conn.id.clone());
     }
 
     // Fall back to managed databases: treat name_or_id as a catalog alias.
     if let Ok(db) = crate::databases::try_resolve_database(api, name_or_id) {
-        return db.default_connection_id;
+        return Ok(db.default_connection_id);
     }
 
-    eprintln!(
-        "{}",
-        format!("error: no connection named or with id '{name_or_id}'").red()
-    );
-    std::process::exit(1);
+    Err(format!("no connection named or with id '{name_or_id}'"))
+}
+
+/// Resolve a connection name or ID to a connection ID, exiting on failure.
+/// Exiting wrapper around [`try_resolve_connection_id`].
+pub fn resolve_connection_id(api: &Api, name_or_id: &str) -> String {
+    use crossterm::style::Stylize;
+    match try_resolve_connection_id(api, name_or_id) {
+        Ok(id) => id,
+        Err(msg) => {
+            eprintln!("{}", format!("error: {msg}").red());
+            std::process::exit(1);
+        }
+    }
 }
 
 pub fn get(workspace_id: &str, connection_id: &str, format: &str) {
@@ -586,5 +601,65 @@ pub fn refresh(
                 eprintln!("    {}", err);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sdk::Api;
+
+    /// A bare connection list with one entry named `good`.
+    fn one_connection_body() -> &'static str {
+        r#"{"connections":[{"id":"conn_good","name":"good","source_type":"postgres"}]}"#
+    }
+
+    #[test]
+    fn try_resolve_connection_id_resolves_by_name() {
+        let mut server = mockito::Server::new();
+        let list = server
+            .mock("GET", "/v1/connections")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(one_connection_body())
+            .create();
+
+        let api = Api::test_new(&server.url(), "k", None);
+        let id = try_resolve_connection_id(&api, "good").unwrap();
+        assert_eq!(id, "conn_good");
+        list.assert();
+    }
+
+    #[test]
+    fn try_resolve_connection_id_returns_err_for_unknown_name() {
+        // The fix: an unknown connection name yields Err instead of exiting the
+        // process, so `databases create --attach` can warn and continue rather
+        // than aborting mid-loop on a typo.
+        let mut server = mockito::Server::new();
+        server
+            .mock("GET", "/v1/connections")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(one_connection_body())
+            .create();
+        // Fallback: the name isn't a managed-database id/catalog/name either.
+        server
+            .mock("GET", "/v1/databases/ghost")
+            .with_status(404)
+            .with_body(r#"{"error":"not found"}"#)
+            .create();
+        server
+            .mock("GET", "/v1/databases")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"databases":[]}"#)
+            .create();
+
+        let api = Api::test_new(&server.url(), "k", None);
+        let err = try_resolve_connection_id(&api, "ghost").unwrap_err();
+        assert!(
+            err.contains("no connection named or with id 'ghost'"),
+            "err: {err}"
+        );
     }
 }

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -600,7 +600,10 @@ pub fn attach(workspace_id: &str, connection: &str, database: Option<&str>, alia
                 .green()
             ),
         },
-        Err(e) => e.exit(),
+        Err(e) => {
+            eprintln!("{}", format!("error: {e}").red());
+            std::process::exit(1);
+        }
     }
 }
 
@@ -768,21 +771,28 @@ fn parse_attach_spec(spec: &str) -> (&str, Option<&str>) {
 
 /// Attach a connection (by name or id) as a catalog on `database_id`. Resolves
 /// the connection then calls the SDK's `attach_catalog`. Returns the resolved
-/// connection id so callers can report it.
+/// connection id so callers can report it, or `Err(message)` on a bad
+/// connection name/id or a failed attach.
+///
+/// Returns the error (rather than exiting) so `create --attach` can warn on one
+/// bad spec and still process the rest. Uses [`try_resolve_connection_id`] for
+/// the same reason — `resolve_connection_id` would `process::exit` on an unknown
+/// name and abort the whole `create` mid-loop.
 fn attach_connection(
     api: &Api,
     database_id: &str,
     connection: &str,
     alias: Option<&str>,
-) -> Result<String, ApiError> {
-    let connection_id = crate::connections::resolve_connection_id(api, connection);
+) -> Result<String, String> {
+    let connection_id = crate::connections::try_resolve_connection_id(api, connection)?;
     let mut request = hotdata::models::AttachDatabaseCatalogRequest::new(connection_id.clone());
     request.alias = alias.map(|a| Some(a.to_string()));
     block(
         api.client()
             .databases()
             .attach_catalog(database_id, request),
-    )?;
+    )
+    .map_err(|e| e.message())?;
     Ok(connection_id)
 }
 
@@ -828,8 +838,7 @@ pub fn create(
                 Err(e) => {
                     eprintln!(
                         "{}",
-                        format!("warning: could not attach '{connection}': {}", e.message())
-                            .yellow()
+                        format!("warning: could not attach '{connection}': {e}").yellow()
                     );
                     None
                 }

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -566,6 +566,82 @@ pub fn get(workspace_id: &str, id_or_name: &str, format: &str) {
     }
 }
 
+/// Attach a connection as a queryable catalog on a managed database, so its
+/// live tables are visible inside that database's query scope (cross-source
+/// joins without exporting data). Defaults to the current database.
+pub fn attach(workspace_id: &str, connection: &str, database: Option<&str>, alias: Option<&str>) {
+    use crossterm::style::Stylize;
+
+    let database = resolve_current_database(database, workspace_id);
+    let api = Api::new(Some(workspace_id));
+    let db = resolve_database(&api, &database);
+    let where_ = db
+        .default_catalog
+        .as_deref()
+        .or(db.name.as_deref())
+        .unwrap_or(&db.id);
+
+    match attach_connection(&api, &db.id, connection, alias) {
+        Ok(_) => match alias {
+            Some(a) => println!(
+                "{}",
+                format!(
+                    "Attached '{connection}' to database '{where_}' as catalog '{a}'.\n\
+                     Query: hotdata query \"SELECT * FROM {a}.<schema>.<table> LIMIT 10\" -d {where_}"
+                )
+                .green()
+            ),
+            None => println!(
+                "{}",
+                format!(
+                    "Attached '{connection}' to database '{where_}'. It is reachable by the \
+                     connection's name; run `hotdata databases {where_}` to see attached catalogs."
+                )
+                .green()
+            ),
+        },
+        Err(e) => e.exit(),
+    }
+}
+
+/// Detach a previously attached connection catalog from a managed database.
+/// Defaults to the current database.
+pub fn detach(workspace_id: &str, connection: &str, database: Option<&str>) {
+    use crossterm::style::Stylize;
+
+    let database = resolve_current_database(database, workspace_id);
+    let api = Api::new(Some(workspace_id));
+    let db = resolve_database(&api, &database);
+    let where_ = db
+        .default_catalog
+        .as_deref()
+        .or(db.name.as_deref())
+        .unwrap_or(&db.id)
+        .to_string();
+    // Detach is keyed by the underlying connection id, but a user who attached
+    // `github=gh` will naturally type `detach gh`. Resolve an attachment alias to
+    // its connection id first; otherwise treat the argument as a connection
+    // name/id like everywhere else.
+    let connection_id = db
+        .attachments
+        .iter()
+        .find(|a| a.alias.as_deref() == Some(connection))
+        .map(|a| a.connection_id.clone())
+        .unwrap_or_else(|| crate::connections::resolve_connection_id(&api, connection));
+
+    block(
+        api.client()
+            .databases()
+            .detach_catalog(&db.id, &connection_id),
+    )
+    .unwrap_or_else(|e| e.exit());
+
+    println!(
+        "{}",
+        format!("Detached '{connection}' from database '{where_}'.").green()
+    );
+}
+
 /// Create a database and return its id. Used by `run` when no
 /// `--database` is given. Mirrors `create`'s request path but returns
 /// the id instead of printing.
@@ -680,6 +756,37 @@ pub fn run(
     }
 }
 
+/// Parse one `--attach` entry into `(connection, alias)`. `conn=alias` sets an
+/// explicit SQL alias; a bare `conn` leaves the alias to default to the
+/// connection's name. The connection part is a name or id resolved later.
+fn parse_attach_spec(spec: &str) -> (&str, Option<&str>) {
+    match spec.split_once('=') {
+        Some((conn, alias)) => (conn.trim(), Some(alias.trim())),
+        None => (spec.trim(), None),
+    }
+}
+
+/// Attach a connection (by name or id) as a catalog on `database_id`. Resolves
+/// the connection then calls the SDK's `attach_catalog`. Returns the resolved
+/// connection id so callers can report it.
+fn attach_connection(
+    api: &Api,
+    database_id: &str,
+    connection: &str,
+    alias: Option<&str>,
+) -> Result<String, ApiError> {
+    let connection_id = crate::connections::resolve_connection_id(api, connection);
+    let mut request = hotdata::models::AttachDatabaseCatalogRequest::new(connection_id.clone());
+    request.alias = alias.map(|a| Some(a.to_string()));
+    block(
+        api.client()
+            .databases()
+            .attach_catalog(database_id, request),
+    )?;
+    Ok(connection_id)
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn create(
     workspace_id: &str,
     name: Option<&str>,
@@ -687,6 +794,7 @@ pub fn create(
     schema: &str,
     tables: &[String],
     expires_at: Option<&str>,
+    attach: &[String],
     format: &str,
 ) {
     use crossterm::style::Stylize;
@@ -704,6 +812,30 @@ pub fn create(
         block(api.client().databases().create(request))
     }
     .unwrap_or_else(|e| e.exit());
+
+    // Attach requested connection catalogs onto the fresh database so a single
+    // `databases create --attach …` lands a cross-source-ready context. A failed
+    // attach is surfaced but non-fatal: the database exists and is usable.
+    let attached: Vec<String> = attach
+        .iter()
+        .filter_map(|spec| {
+            let (connection, alias) = parse_attach_spec(spec);
+            match attach_connection(&api, &resp.id, connection, alias) {
+                Ok(_) => Some(match alias {
+                    Some(a) => format!("{connection} (as {a})"),
+                    None => connection.to_string(),
+                }),
+                Err(e) => {
+                    eprintln!(
+                        "{}",
+                        format!("warning: could not attach '{connection}': {}", e.message())
+                            .yellow()
+                    );
+                    None
+                }
+            }
+        })
+        .collect();
 
     let result = CreateDatabaseResponse {
         id: resp.id,
@@ -735,6 +867,9 @@ pub fn create(
             println!("id:          {}", result.id);
             if let Some(exp) = &result.expires_at {
                 println!("expires_at:  {exp}");
+            }
+            if !attached.is_empty() {
+                println!("attached:    {}", attached.join(", ").cyan());
             }
             println!();
             let catalog = result
@@ -1126,6 +1261,24 @@ mod tests {
     fn schema_name_defaults_to_public() {
         assert_eq!(schema_name(None), "public");
         assert_eq!(schema_name(Some("custom")), "custom");
+    }
+
+    #[test]
+    fn parse_attach_spec_bare_connection_has_no_alias() {
+        assert_eq!(parse_attach_spec("github"), ("github", None));
+    }
+
+    #[test]
+    fn parse_attach_spec_splits_alias() {
+        assert_eq!(parse_attach_spec("github=gh"), ("github", Some("gh")));
+    }
+
+    #[test]
+    fn parse_attach_spec_trims_whitespace() {
+        assert_eq!(
+            parse_attach_spec("  salesdb = sales "),
+            ("salesdb", Some("sales"))
+        );
     }
 
     #[test]

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -581,29 +581,30 @@ pub fn attach(workspace_id: &str, connection: &str, database: Option<&str>, alia
         .or(db.name.as_deref())
         .unwrap_or(&db.id);
 
-    match attach_connection(&api, &db.id, connection, alias) {
-        Ok(_) => match alias {
-            Some(a) => println!(
-                "{}",
-                format!(
-                    "Attached '{connection}' to database '{where_}' as catalog '{a}'.\n\
-                     Query: hotdata query \"SELECT * FROM {a}.<schema>.<table> LIMIT 10\" -d {where_}"
-                )
-                .green()
-            ),
-            None => println!(
-                "{}",
-                format!(
-                    "Attached '{connection}' to database '{where_}'. It is reachable by the \
-                     connection's name; run `hotdata databases {where_}` to see attached catalogs."
-                )
-                .green()
-            ),
-        },
-        Err(e) => {
-            eprintln!("{}", format!("error: {e}").red());
-            std::process::exit(1);
-        }
+    // Resolve + attach via the exiting paths (mirroring `detach`): a bad name
+    // exits with the resolver's message, and an API failure goes through
+    // `ApiError::exit`, which upgrades a masked 401/403 into the re-auth hint.
+    // (The non-fatal `create --attach` loop uses `attach_connection` instead.)
+    let connection_id = crate::connections::resolve_connection_id(&api, connection);
+    send_attach(&api, &db.id, connection_id, alias).unwrap_or_else(|e| e.exit());
+
+    match alias {
+        Some(a) => println!(
+            "{}",
+            format!(
+                "Attached '{connection}' to database '{where_}' as catalog '{a}'.\n\
+                 Query: hotdata query \"SELECT * FROM {a}.<schema>.<table> LIMIT 10\" -d {where_}"
+            )
+            .green()
+        ),
+        None => println!(
+            "{}",
+            format!(
+                "Attached '{connection}' to database '{where_}'. It is reachable by the \
+                 connection's name; run `hotdata databases {where_}` to see attached catalogs."
+            )
+            .green()
+        ),
     }
 }
 
@@ -769,15 +770,36 @@ fn parse_attach_spec(spec: &str) -> (&str, Option<&str>) {
     }
 }
 
-/// Attach a connection (by name or id) as a catalog on `database_id`. Resolves
-/// the connection then calls the SDK's `attach_catalog`. Returns the resolved
-/// connection id so callers can report it, or `Err(message)` on a bad
-/// connection name/id or a failed attach.
+/// POST the attach request for an already-resolved `connection_id`. The single
+/// place the `AttachDatabaseCatalogRequest` (incl. the double-Option alias) is
+/// built, so the standalone `attach` command and the `create --attach` loop
+/// share one request shape while handling the error differently (exit vs warn).
+fn send_attach(
+    api: &Api,
+    database_id: &str,
+    connection_id: String,
+    alias: Option<&str>,
+) -> Result<(), ApiError> {
+    let mut request = hotdata::models::AttachDatabaseCatalogRequest::new(connection_id);
+    request.alias = alias.map(|a| Some(a.to_string()));
+    block(
+        api.client()
+            .databases()
+            .attach_catalog(database_id, request),
+    )
+    .map(|_| ())
+}
+
+/// Attach a connection (by name or id) as a catalog on `database_id`, returning
+/// the resolved connection id or `Err(message)` on a bad connection name/id or a
+/// failed attach.
 ///
 /// Returns the error (rather than exiting) so `create --attach` can warn on one
 /// bad spec and still process the rest. Uses [`try_resolve_connection_id`] for
 /// the same reason — `resolve_connection_id` would `process::exit` on an unknown
-/// name and abort the whole `create` mid-loop.
+/// name and abort the whole `create` mid-loop. The standalone `attach` command
+/// does NOT use this — it wants the auth-aware [`ApiError::exit`], so it calls
+/// `resolve_connection_id` + [`send_attach`] directly.
 fn attach_connection(
     api: &Api,
     database_id: &str,
@@ -785,14 +807,7 @@ fn attach_connection(
     alias: Option<&str>,
 ) -> Result<String, String> {
     let connection_id = crate::connections::try_resolve_connection_id(api, connection)?;
-    let mut request = hotdata::models::AttachDatabaseCatalogRequest::new(connection_id.clone());
-    request.alias = alias.map(|a| Some(a.to_string()));
-    block(
-        api.client()
-            .databases()
-            .attach_catalog(database_id, request),
-    )
-    .map_err(|e| e.message())?;
+    send_attach(api, database_id, connection_id.clone(), alias).map_err(|e| e.message())?;
     Ok(connection_id)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -324,6 +324,7 @@ fn main() {
                             schema,
                             tables,
                             expires_at,
+                            attach,
                             output,
                         }) => databases::create(
                             &workspace_id,
@@ -332,8 +333,23 @@ fn main() {
                             &schema,
                             &tables,
                             expires_at.as_deref(),
+                            &attach,
                             &output,
                         ),
+                        Some(DatabasesCommands::Attach {
+                            connection,
+                            database,
+                            alias,
+                        }) => databases::attach(
+                            &workspace_id,
+                            &connection,
+                            database.as_deref(),
+                            alias.as_deref(),
+                        ),
+                        Some(DatabasesCommands::Detach {
+                            connection,
+                            database,
+                        }) => databases::detach(&workspace_id, &connection, database.as_deref()),
                         Some(DatabasesCommands::Set { id }) => databases::set(&workspace_id, &id),
                         Some(DatabasesCommands::Unset) => databases::unset(&workspace_id),
                         Some(DatabasesCommands::Delete { name_or_id }) => {

--- a/src/query.rs
+++ b/src/query.rs
@@ -376,6 +376,20 @@ fn fail_query(err: &ApiError, error_msg: &str) -> ! {
     std::process::exit(1);
 }
 
+/// Print a failed query run's `query failed: <err>` line, append the cross-source
+/// hint when applicable, then exit non-zero. Shared by both terminal-failure
+/// sites — `execute`'s poll loop and the `query status` (`poll`) command — so the
+/// hint surfaces identically whether the failure is seen inline or on a later
+/// poll.
+fn fail_run(error_msg: &str) -> ! {
+    use crossterm::style::Stylize;
+    eprintln!("{}", format!("query failed: {error_msg}").red());
+    if let Some(tip) = cross_source_hint(error_msg) {
+        eprintln!("{}", tip.dark_grey());
+    }
+    std::process::exit(1);
+}
+
 pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &str) {
     let api = Api::new(Some(workspace_id));
 
@@ -441,16 +455,11 @@ pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &s
             }
             "failed" => {
                 spinner.finish_and_clear();
-                use crossterm::style::Stylize;
                 let err = run
                     .error_message
                     .flatten()
                     .unwrap_or_else(|| "unknown error".to_string());
-                eprintln!("{}", format!("query failed: {err}").red());
-                if let Some(tip) = cross_source_hint(&err) {
-                    eprintln!("{}", tip.dark_grey());
-                }
-                std::process::exit(1);
+                fail_run(&err);
             }
             "running" | "queued" | "pending" => {}
             status => {
@@ -497,13 +506,11 @@ pub fn poll(query_run_id: &str, workspace_id: &str, format: &str) {
             }
         },
         "failed" => {
-            use crossterm::style::Stylize;
             let err = run
                 .error_message
                 .flatten()
                 .unwrap_or_else(|| "unknown error".to_string());
-            eprintln!("{}", format!("query failed: {err}").red());
-            std::process::exit(1);
+            fail_run(&err);
         }
         status => {
             use crossterm::style::Stylize;

--- a/src/query.rs
+++ b/src/query.rs
@@ -329,6 +329,53 @@ fn incomplete_preview(resp: hotdata::models::QueryResponse, note: &str) -> Query
     preview
 }
 
+/// When a query fails because it has no database context or references a
+/// catalog that isn't in scope, return a one-line hint pointing at
+/// `databases set` / `databases attach`. Pure string inspection of the server
+/// error so it's unit-testable and adds no network round-trip on success.
+///
+/// A `query` runs inside exactly one managed database; that context exposes the
+/// database's own catalog plus any *attached* connection catalogs. The two
+/// failure modes a user hits when they don't know this are "a database is
+/// required" (no context set) and "table '<catalog>.<schema>.<table>' not
+/// found" (the catalog isn't attached) — both resolved by attaching.
+fn cross_source_hint(error_msg: &str) -> Option<String> {
+    let lower = error_msg.to_lowercase();
+    if lower.contains("a database is required") {
+        return Some(
+            "Tip: a query runs inside one managed database. Set one with `hotdata databases \
+             set <id>`, then attach any connection whose tables you need: `hotdata databases \
+             attach <connection>`. List connections with `hotdata connections list`."
+                .to_string(),
+        );
+    }
+    // "table 'catalog.schema.table' not found" — surface the catalog so the user
+    // can attach it if it's a connection simply outside this database's scope.
+    if lower.contains("not found")
+        && let Some(quoted) = error_msg.split('\'').nth(1)
+        && quoted.contains('.')
+        && let Some(catalog) = quoted.split('.').next().filter(|c| !c.is_empty())
+    {
+        return Some(format!(
+            "Tip: '{catalog}' isn't in the current database's scope. If it's a connection, \
+             attach it to query across sources: `hotdata databases attach {catalog}`."
+        ));
+    }
+    None
+}
+
+/// Print the API error, append the cross-source hint when one applies, then
+/// exit non-zero. Used on both query failure paths (submit error and async
+/// `failed`) so the hint shows after the error regardless of which one fires.
+fn fail_query(err: &ApiError, error_msg: &str) -> ! {
+    err.print();
+    if let Some(tip) = cross_source_hint(error_msg) {
+        use crossterm::style::Stylize;
+        eprintln!("{}", tip.dark_grey());
+    }
+    std::process::exit(1);
+}
+
 pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &str) {
     let api = Api::new(Some(workspace_id));
 
@@ -346,7 +393,10 @@ pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &s
         "running query...",
         api.client().submit_query(request, database),
     )
-    .unwrap_or_else(|e| e.exit());
+    .unwrap_or_else(|e| {
+        let msg = e.message();
+        fail_query(&e, &msg)
+    });
 
     let async_resp = match outcome {
         // Completed within async_after_ms — inline results. A large result can
@@ -397,6 +447,9 @@ pub fn execute(sql: &str, workspace_id: &str, database: Option<&str>, format: &s
                     .flatten()
                     .unwrap_or_else(|| "unknown error".to_string());
                 eprintln!("{}", format!("query failed: {err}").red());
+                if let Some(tip) = cross_source_hint(&err) {
+                    eprintln!("{}", tip.dark_grey());
+                }
                 std::process::exit(1);
             }
             "running" | "queued" | "pending" => {}
@@ -605,6 +658,40 @@ mod tests {
         );
         resp.result_id = Some(result_id.map(|s| s.to_string()));
         resp
+    }
+
+    #[test]
+    fn hint_for_missing_database_context() {
+        let tip = cross_source_hint(
+            "a database is required: set the X-Database-Id header or the database_id body field",
+        )
+        .expect("missing-database error should produce a hint");
+        assert!(tip.contains("hotdata databases set"), "tip: {tip}");
+        assert!(tip.contains("hotdata databases attach"), "tip: {tip}");
+    }
+
+    #[test]
+    fn hint_for_unattached_catalog_names_the_catalog() {
+        let tip = cross_source_hint("table 'github.github.issues' not found")
+            .expect("qualified not-found should produce a hint");
+        // The catalog (first dotted segment), not the schema/table, drives the hint.
+        assert!(tip.contains("'github'"), "tip: {tip}");
+        assert!(
+            tip.contains("hotdata databases attach github"),
+            "tip: {tip}"
+        );
+    }
+
+    #[test]
+    fn no_hint_for_unqualified_not_found() {
+        // A bare name (no catalog prefix) isn't an attach problem — don't guess.
+        assert!(cross_source_hint("table 'orders' not found").is_none());
+    }
+
+    #[test]
+    fn no_hint_for_unrelated_error() {
+        assert!(cross_source_hint("syntax error at or near \"SELCT\"").is_none());
+        assert!(cross_source_hint("429: OVERLOADED").is_none());
     }
 
     #[test]

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -221,11 +221,15 @@ impl ApiError {
         }
     }
 
-    /// Print the standard error and exit, reproducing `ApiClient::fail_response`.
+    /// Print the standard error (without exiting), reproducing
+    /// `ApiClient::fail_response`'s formatting.
     ///
     /// On a 4xx, re-probe the auth status so a masked 404/403 is upgraded into
-    /// the "run hotdata auth" hint; otherwise surface the server body.
-    pub fn exit(&self) -> ! {
+    /// the "run hotdata auth" hint; otherwise surface the server body. Split out
+    /// from [`exit`](Self::exit) so callers that want to append their own hint
+    /// after the error (e.g. the query cross-source hint) can print, add the
+    /// hint, then exit.
+    pub fn print(&self) {
         match self {
             ApiError::Status { status, body } => {
                 let auth_status = if status.is_client_error() {
@@ -246,6 +250,11 @@ impl ApiError {
                 eprintln!("{msg}");
             }
         }
+    }
+
+    /// Print the standard error and exit, reproducing `ApiClient::fail_response`.
+    pub fn exit(&self) -> ! {
+        self.print();
         std::process::exit(1);
     }
 }

--- a/tests/databases_cli.rs
+++ b/tests/databases_cli.rs
@@ -17,6 +17,49 @@ fn databases_help_lists_subcommands() {
     assert!(help.contains("create"));
     assert!(help.contains("delete"));
     assert!(help.contains("tables"));
+    assert!(help.contains("attach"));
+    assert!(help.contains("detach"));
+}
+
+#[test]
+fn databases_create_help_documents_attach_flag() {
+    let output = hotdata()
+        .args(["databases", "create", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(help.contains("--attach"), "help: {help}");
+    // The `connection=alias` form is the documented way to set the SQL alias.
+    assert!(help.contains("connection=alias"), "help: {help}");
+}
+
+#[test]
+fn databases_attach_help_documents_connection_and_alias() {
+    let output = hotdata()
+        .args(["databases", "attach", "--help"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let help = String::from_utf8_lossy(&output.stdout);
+    assert!(help.contains("--alias"), "help: {help}");
+    assert!(help.contains("--database"), "help: {help}");
+}
+
+#[test]
+fn databases_attach_requires_a_connection_argument() {
+    // `connection` is a required positional — parsing must fail without it.
+    let output = hotdata().args(["databases", "attach"]).output().unwrap();
+    assert!(!output.status.success());
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("required") || combined.contains("CONNECTION"),
+        "output: {combined}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Every `hotdata query` runs inside one managed database, whose scope only sees its own catalog plus connection catalogs explicitly attached to it. The CLI had no way to attach a connection, so connection tables were unqueryable and cross-source joins impossible — agents were forced into an export-to-parquet workaround.

Adds `hotdata databases attach <connection> [--alias]` / `detach`, a repeatable `--attach <conn>[=alias]` on `databases create`, and query failure hints pointing at attach (on "a database is required" and "table not found"). Skills and README updated to document the query execution context and the live, sync-preserving cross-source path. Verified end-to-end against the live service.