### PR TITLE
fix(databases): suppress current-database footer for non-TTY stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,13 @@ unsafe extern "C" {
 
 extern "C" fn print_database_footer() {
     use crossterm::style::Stylize;
+    use std::io::IsTerminal;
+    // Human convenience only — stay quiet for piped/redirected/scripted
+    // callers (who may capture stderr alongside machine output) so the footer
+    // never mixes into their stream.
+    if !std::io::stdout().is_terminal() {
+        return;
+    }
     // Inside a `databases run` child the parent already announced the
     // database at spawn, so stay silent here.
     if database_session::database_token_in_use().is_some() {


### PR DESCRIPTION
## What

Gate the `current database:` footer (the `atexit` handler `print_database_footer`) on an interactive stdout, so it only prints when a person is at a terminal.

## Why

The footer prints to **stderr** after every database-touching command, including machine-output runs (`-o json`/`-o csv`). It does not corrupt stdout, but any script/agent that captures stderr alongside stdout picks up this human-oriented line as noise. Piped/redirected/CI/agent invocations are exactly the non-TTY case, so an `stdout().is_terminal()` guard targets the actual harm with one line and no per-command plumbing.

## Change

```rust
// src/main.rs — print_database_footer()
if !std::io::stdout().is_terminal() {
    return;
}
```

## Verification

- Piped stdout (`databases list -o json 2>&1 >/dev/null`): **0** footer lines; stdout remains valid JSON.
- Under a PTY (`script -q /dev/null …`): footer **still shown** — interactive UX unchanged.
- `cargo test`: **231 passed, 0 failed**.

Found during a full E2E pass of the CLI against production. Independent of #179 (the BM25 `score`-column collision).
