### PR TITLE
chore: release hotdata-cli v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [0.10.0] - 2026-06-29
+
+### 🚀 Features
+
+- *(upload)* Very large or slow `databases load` uploads no longer fail partway through — each part's upload link is now fetched just in time and renewed automatically if it expires
+
+### 💼 Other
+
+- *(auth)* `hotdata auth` now shows help instead of auto-launching a browser login — run `hotdata auth login` to sign in; adds `auth profiles` to scaffold profiles.yml (#182)
+
+### 📚 Documentation
+
+- *(skills)* Update bundled skill docs to match current commands and auth
+
 ## [0.9.0] - 2026-06-27
 
 ### 🚀 Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b519aaebaee3089cf13b7eb47a64517271e881200319d51ebbb6fd3cbf3909"
+checksum = "f77aa9f06ee71c09dd1d6805b862eae1f8ba47f28e29e3055e7d1efb56dc039a"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "hotdata-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
 # decode; `upload_file` runs the presigned direct-to-storage upload flow
 # (see src/sdk.rs::Api::upload).
-hotdata = { version = "0.5.0", features = ["arrow"] }
+hotdata = { version = "0.6.0", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). The presigned
 # upload (src/sdk.rs::Api::upload) drives the SDK's async `upload_file` on this

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotdata-cli"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 repository = "https://github.com/hotdata-dev/hotdata-cli"
 description = "CLI tool for Hotdata.dev"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br>
   Command line interface for <a href="https://www.hotdata.dev">Hotdata</a>.
   <br><br>
-  <img src="https://img.shields.io/badge/version-0.9.0-blue" alt="version">
+  <img src="https://img.shields.io/badge/version-0.10.0-blue" alt="version">
   <a href="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml"><img src="https://github.com/hotdata-dev/hotdata-cli/actions/workflows/ci.yml/badge.svg" alt="build"></a>
   <a href="https://codecov.io/gh/hotdata-dev/hotdata-cli"><img src="https://codecov.io/gh/hotdata-dev/hotdata-cli/branch/main/graph/badge.svg" alt="coverage"></a>
 </p>

--- a/skills/hotdata-analytics/SKILL.md
+++ b/skills/hotdata-analytics/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-analytics
 description: Use this skill when the user wants OLAP-style SQL analytics in Hotdata — aggregations, GROUP BY, JOINs, reporting, exploratory queries, query run history, stored results, or materialized follow-up tables (Chain into managed databases). Activate for "analyze", "aggregate", "rollup", "pivot", "report", "metrics", "GROUP BY", "query history", "past queries", "query runs", "stored results", "materialize", "chain", "intermediate table", or sorted indexes for filters/range scans. Do not load for BM25/vector search or geospatial SQL — use hotdata-search or hotdata-geospatial. Requires the core hotdata skill for connections, tables, and auth.
-version: 0.9.0
+version: 0.10.0
 ---
 
 # Hotdata Analytics Skill

--- a/skills/hotdata-geospatial/SKILL.md
+++ b/skills/hotdata-geospatial/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-geospatial
 description: Use this skill only when the user is working with geospatial data in Hotdata (PostGIS-style SQL like ST_* functions, geometry/WKB, bbox filtering, point-in-polygon, distance/area, lat/lon, spatial joins, “geospatial”, “GIS”, “PostGIS”). Do not load this skill for non-geospatial SQL or general Hotdata usage.
-version: 0.9.0
+version: 0.10.0
 ---
 
 # Hotdata Geospatial Skill

--- a/skills/hotdata-search/SKILL.md
+++ b/skills/hotdata-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata-search
 description: Use this skill when the user wants full-text search, BM25 keyword search, vector similarity search, semantic search, embeddings, or retrieval indexes in Hotdata. Activate for "hotdata search", "BM25", "full-text", "vector search", "semantic search", "similarity", "embedding", "embedding provider", "create an index" (bm25 or vector), "list indexes" for search, or SQL using bm25_search or vector_distance. Do not load for general SQL analytics (aggregations, GROUP BY) or geospatial work — use hotdata-analytics or hotdata-geospatial instead. Requires the core hotdata skill for auth and workspace basics.
-version: 0.9.0
+version: 0.10.0
 ---
 
 # Hotdata Search Skill

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: hotdata
 description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, tables, basic SQL query, database context (context:DATAMODEL), jobs, and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "execute a query", "database context", "context:DATAMODEL", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
-version: 0.9.0
+version: 0.10.0
 ---
 
 # Hotdata CLI Skill


### PR DESCRIPTION
Bumps the hotdata SDK to 0.6.0 (just-in-time presigned part-URL minting, so large/slow `databases load` uploads no longer fail on URL expiry — verified end-to-end with a 15 GB upload) and cuts CLI v0.10.0.

Tag `v0.10.0` after merge to trigger cargo-dist (binaries + Homebrew).