### PR TITLE
fix(jobs): accept managed_load as --job-type filter (#160)

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -381,7 +381,7 @@ pub enum JobsCommands {
     /// List background jobs (shows active jobs by default)
     List {
         /// Filter by job type
-        #[arg(long, value_parser = ["data_refresh_table", "data_refresh_connection", "create_index"])]
+        #[arg(long, value_parser = ["data_refresh_table", "data_refresh_connection", "create_index", "managed_load"])]
         job_type: Option<String>,
 
         /// Filter by status

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -41,6 +41,7 @@ fn parse_job_type(s: &str) -> Option<JobType> {
         "data_refresh_table" => Some(JobType::DataRefreshTable),
         "data_refresh_connection" => Some(JobType::DataRefreshConnection),
         "create_index" => Some(JobType::CreateIndex),
+        "managed_load" => Some(JobType::ManagedLoad),
         _ => None,
     }
 }
@@ -100,6 +101,37 @@ pub fn get(job_id: &str, workspace_id: &str, format: &str) {
             }
         }
         _ => unreachable!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hotdata::models::ListJobsResponse;
+
+    // Regression for #160: a `managed_load` row must deserialize, not blow up
+    // the whole `jobs list` response. Proves SDK 0.6.0's JobType carries the
+    // variant the server emits for `databases load`.
+    #[test]
+    fn list_response_with_managed_load_deserializes() {
+        let body = r#"{
+            "jobs": [
+                {
+                    "id": "job_1",
+                    "job_type": "managed_load",
+                    "status": "succeeded",
+                    "attempts": 1,
+                    "created_at": "2026-06-18T06:00:00Z"
+                }
+            ]
+        }"#;
+        let resp: ListJobsResponse = serde_json::from_str(body).expect("managed_load must parse");
+        assert_eq!(resp.jobs[0].job_type, JobType::ManagedLoad);
+    }
+
+    #[test]
+    fn parse_job_type_accepts_managed_load() {
+        assert_eq!(parse_job_type("managed_load"), Some(JobType::ManagedLoad));
     }
 }
 


### PR DESCRIPTION
Closes #160.

## TL;DR
The reported **crash** is already fixed; this PR closes the **remaining filter gap**.

## What #160 actually is, after investigation
The issue was filed against CLI 0.5.0 / SDK 0.3.1. Verifying against current `main` (not the issue body):

- **Crash already resolved.** The CLI now depends on SDK `0.6.0` (commit `c803d22`, shipped in 0.10.0), whose `JobType` enum includes `ManagedLoad`. A `managed_load` row in `jobs list` now deserializes cleanly instead of failing the whole response. Proven by a new test (`list_response_with_managed_load_deserializes`) that passed *before* this PR's code change.
- **No runtimedb changes needed.** `runtimedb/openapi.yaml` already defines all `JobType` variants and the SDK (generated in `hotdata-dev/sdk-rust`) matches it.
- **Remaining gap (this PR).** `--job-type managed_load` was still rejected — both the clap `value_parser` (`command.rs`) and `parse_job_type` (`jobs.rs`) were stale, last touched when the SDK had only 4 user-facing types.

## Why `managed_load` is correct to surface to customers
runtimedb's `is_maintenance()` (#740) deliberately hides only the 5 internal maintenance jobs (`ducklake_vacuum`, `ducklake_orphan_cleanup`, `result_deletion`, `stale_result_cleanup`, `result_retention`) from listings — and `managed_load` is intentionally **not** among them. It's the job created by `hotdata databases load`. The displayed TYPE stays the raw `managed_load` token, consistent with the other four job types (no friendly-label layer exists today; introducing one is a separate, all-types decision).

## Changes
- `src/command.rs`: add `managed_load` to the `--job-type` `value_parser`.
- `src/jobs.rs`: map `managed_load` → `JobType::ManagedLoad` in `parse_job_type`; add two regression tests.

## Verification
- `cargo test --bin hotdata`: 237 passed.
- `cargo clippy`: clean on touched files.
- `hotdata jobs list --job-type managed_load` is accepted; invalid values list `managed_load` among possible values.

## Follow-ups (out of scope, not done here)
- The customer-facing docs at `www.hotdata.dev/content/docs/cli-reference.md` list the same stale `--job-type` set and should add `managed_load`.
- Optional SDK hardening: a `#[serde(other)]` catch-all in `hotdata-dev/sdk-rust`'s generated `JobType` so future unknown server job types degrade gracefully instead of crashing `jobs list`.
