### PR TITLE
chore(deps): bump hotdata SDK to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1165,9 +1165,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hotdata"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77aa9f06ee71c09dd1d6805b862eae1f8ba47f28e29e3055e7d1efb56dc039a"
+checksum = "9d820a420f191d02017b94c3814e8305cab0442f47f785732ae4df0a240c1754"
 dependencies = [
  "arrow-array",
  "arrow-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # behind a shared multi-thread tokio runtime. The `arrow` feature backs result
 # decode; `upload_file` runs the presigned direct-to-storage upload flow
 # (see src/sdk.rs::Api::upload).
-hotdata = { version = "0.6.0", features = ["arrow"] }
+hotdata = { version = "0.7.0", features = ["arrow"] }
 # Shared multi-thread runtime for the sync wrapper; block_on is called
 # concurrently from rayon worker threads (see src/indexes.rs). The presigned
 # upload (src/sdk.rs::Api::upload) drives the SDK's async `upload_file` on this


### PR DESCRIPTION
Picks up resilient multipart upload retries (per-part re-sweep + per-part PUT timeout) and per-part just-in-time URL minting from sdk-rust v0.7.0. CLI builds and all unit tests pass against the new version.