### PR TITLE
feat(ingest)!: datasources rename + stop leaking service internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,23 +87,27 @@ into a managed database:
 hotdata ingest connectors                   # browse: SQL dialects, ~150 API services,
                                             # buckets, iceberg, api (bring-your-own)
 
-# Add a connection — validates credentials and discovers the schema, loads no data.
+# Add a datasource — validates credentials and discovers the schema, loads no data.
 # Keep secrets out of argv with --config @file.json or @- (stdin):
-hotdata ingest new-connection --service postgres --config @conn.json --schema public
-hotdata ingest new-connection --service buckets --bucket-url s3://bucket/prefix --format parquet
-hotdata ingest new-connection --service iceberg --config @catalog.json --table ns.orders
+hotdata ingest new-datasource --service postgres --config @conn.json --schema public
+hotdata ingest new-datasource --service buckets --bucket-url s3://bucket/prefix --format parquet
+hotdata ingest new-datasource --service iceberg --config @catalog.json --table ns.orders
 
-# Import — a plain SELECT against the connection; returns immediately:
-hotdata ingest new-import "SELECT * FROM postgres.orders WHERE status = 'open'"
-hotdata ingest new-import --source postgres --all
-hotdata ingest status <ingest-id> --wait    # or one-shot: exits 0 done / 1 failed / 2 running
+# --name sets the FROM target (default: the connector name), so several
+# datasources of one connector can coexist:
+hotdata ingest new-datasource --service postgres --name prod_pg --config @conn.json
+
+# Import — a plain SELECT against the datasource; returns immediately:
+hotdata ingest new-import "SELECT * FROM prod_pg.orders WHERE status = 'open'"
+hotdata ingest new-import --source prod_pg --all
+hotdata ingest status <import-id> --wait    # or one-shot: exits 0 done / 1 failed / 2 running
 
 # The import lands in a managed database — query it like any other:
 hotdata query --database <db-id> "SELECT count(*) FROM public.orders"
 ```
 
 Public buckets need no credentials. Re-run an import any time with
-`hotdata ingest trigger-import <ingest-id>` — it refreshes the same database
+`hotdata ingest trigger-import <import-id>` — it refreshes the same database
 from the source.
 
 ### Upload files

--- a/skills/hotdata/SKILL.md
+++ b/skills/hotdata/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hotdata
-description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, tables, basic SQL query, database context (context:DATAMODEL), jobs, ingest (pull external data), and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "execute a query", "database context", "context:DATAMODEL", "ingest", "import data from", "connect a data source", "connector", "pull data from postgres/mysql/an API/S3 buckets/Iceberg", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
+description: Use this skill when the user wants to run core hotdata CLI commands — auth, workspaces, connections, managed databases, tables, basic SQL query, database context (context:DATAMODEL), jobs, ingest (pull external data), and skill install. Activate for "run hotdata", "list workspaces", "list connections", "create a connection", "list databases", "managed database", "load parquet", "list tables", "execute a query", "database context", "context:DATAMODEL", "ingest", "datasource", "import data from", "connect a data source", "connector", "pull data from postgres/mysql/an API/S3 buckets/Iceberg", or general Hotdata CLI usage. For full-text/vector search and retrieval indexes use hotdata-search; for OLAP analytics, query history, stored results, and Chain materializations use hotdata-analytics; for geospatial/GIS use hotdata-geospatial.
 version: 0.13.1
 ---
 
@@ -297,53 +297,58 @@ hotdata jobs <job_id> [--workspace-id <workspace_id>] [--output table|json|yaml]
 
 ### Ingest external data (`ingest`)
 
-Pull data from external sources (SQL databases, APIs, S3/GCS/Azure buckets, Iceberg catalogs) into managed databases. Two nouns: **connections** (onboarded, credentialed sources — schema discovered, no data loaded; each has its own id) and **imports** (managed databases materialized from a connection). A connection registers under the connector name you added (`postgres`, `buckets`, `iceberg`, a named API service) — that name is the `FROM` target for imports.
+Pull data from external sources (SQL databases, APIs, S3/GCS/Azure buckets, Iceberg catalogs) into managed databases. Two nouns: **datasources** (added, credentialed sources — schema discovered, no data loaded; each has its own id) and **imports** (managed databases materialized from a datasource). A datasource answers to its **name** — `--name` if you chose one, otherwise the connector name (`postgres`, `buckets`, …) — and that name is the `FROM` target for imports.
 
-Enqueue commands (`new-connection`, `new-import`, `trigger-import`, `delete-connection`) **require a workspace API key** (`HOTDATA_API_KEY` / `--api-key`, `hd_...`) — a login session is not enough, because the ingest pipeline runs after a short-lived session token would expire.
+Commands that create or change things (`new-datasource`, `new-import`, `trigger-import`, `delete-datasource`) **require a workspace API key** (`HOTDATA_API_KEY` / `--api-key`, `hd_...`); a login session is not accepted.
 
 ```bash
-hotdata ingest connectors [filter]     # browse the catalog; "active" = already added.
-                                       # SQL dialects + ~150 named API services + generic
-                                       # buckets / iceberg / api (bring-your-own config)
-hotdata ingest new-connection --service postgres --config @conn.json --schema public
+hotdata ingest connectors [filter]     # browse the catalog; "added" = you have a
+                                       # datasource for it. SQL dialects + ~150 named
+                                       # API services + generic buckets / iceberg / api.
+                                       # -o json includes each entry's config_schema —
+                                       # the exact fields --config takes.
+hotdata ingest new-datasource --service postgres --config @conn.json --schema public
 # conn.json holds {"connection_string": "postgresql://user:pass@host/db"}
 # --config accepts @file.json, @- (stdin), or inline JSON — keep secrets out of argv.
 # Validates credentials + discovers the schema; loads NO data. Blocks until done
 # and prints the discovered tables (--no-wait to return immediately).
+# --name prod_pg names the datasource (identifier-shaped; default = connector name),
+# so several datasources of one connector can coexist: FROM prod_pg.
 
-hotdata ingest new-connection --service buckets --bucket-url s3://bucket/prefix --format parquet
+hotdata ingest new-datasource --service buckets --bucket-url s3://bucket/prefix --format parquet
 # Files in S3/GCS/Azure buckets (csv, jsonl, parquet); --glob narrows the match.
 # Public buckets need no credentials; private ones take --config @creds.json
 # ({"aws_access_key_id": …, "aws_secret_access_key": …, "endpoint_url": …}).
 
-hotdata ingest new-connection --service iceberg --config @catalog.json --table ns.orders
+hotdata ingest new-datasource --service iceberg --config @catalog.json --table ns.orders
 # Iceberg via a REST catalog. --table is REQUIRED (repeatable, namespace.table).
-# catalog.json = pyiceberg catalog properties passed verbatim — {"uri": …,
-# "warehouse": …, "token": …} or "credential" + "scope" for an OAuth exchange.
+# catalog.json fields: {"uri": …, "warehouse": …, "token": …} or "credential" +
+# "scope" for an OAuth exchange — see the iceberg config_schema in `connectors -o json`.
 
-hotdata ingest list-connections               # ids, statuses; --all includes superseded
-hotdata ingest show-connection <id>           # status + discovered tables/columns
-hotdata ingest delete-connection <id>         # registry + credentials + discovery DB
-                                              # (--keep-database keeps the DB)
+hotdata ingest list-datasources               # names, ids, statuses; --all includes replaced ones
+hotdata ingest show-datasource <id>           # status + discovered tables/columns
+hotdata ingest delete-datasource <id>         # removes it (stored credentials included);
+                                              # existing imports keep working
 
 # Imports return IMMEDIATELY (non-blocking). Track with `status`:
-hotdata ingest new-import "SELECT * FROM postgres.orders LIMIT 1000"
-hotdata ingest new-import --source postgres --all       # everything, no LIMIT
-hotdata ingest status <ingest-id>             # one-shot; exits 0 done / 1 failed / 2 in flight
-hotdata ingest status <ingest-id> --wait      # attach and poll to done/failed
+hotdata ingest new-import "SELECT * FROM prod_pg.orders LIMIT 1000"
+hotdata ingest new-import --source prod_pg --all        # everything, no LIMIT
+hotdata ingest status <import-id>             # one-shot; exits 0 done / 1 failed / 2 in flight
+hotdata ingest status <import-id> --wait      # attach and poll to done/failed
 
 hotdata ingest list-imports                   # the SQL behind each import + its database
-hotdata ingest trigger-import <ingest-id>     # re-run: refresh the same DB from source
+hotdata ingest trigger-import <import-id>     # re-run: refresh the same DB from source
 ```
 
 Agent tips:
-- Import SQL is a **restricted grammar**: `SELECT <cols|*> FROM <connection>[.<resource>] [WHERE …] [LIMIT n]` — no joins/GROUP BY. Run real analytics with `hotdata query` against the imported database afterward.
+- Import SQL is a **restricted grammar**: `SELECT <cols|*> FROM <datasource>[.<table>] [WHERE …] [LIMIT n]` — no joins/GROUP BY. Run real analytics with `hotdata query` against the imported database afterward.
 - Prefer `-o json` + the `status` exit codes for scripting; poll one-shot `status` rather than holding `--wait` when doing other work in between.
-- In-flight statuses stream through stages (`preparing`, `extracting`, `normalizing`, `loading`); treat **any non-terminal value as in-flight** — the set can grow. Terminal = `done` | `failed`.
+- `status` is a **closed set**: `pending` | `running` | `done` | `failed`. While running, the finer progress state (e.g. `extracting`, `loading`) appears in `stage` — informational only, never switch on it.
 - Tables print oldest→newest; `-o json` is newest-first (`[0]` = latest).
 - Once an import is `done`, its database is a regular managed DB: query it with `hotdata query --database <db-id> "SELECT … FROM public.<table>"`.
-- Resources per family: `buckets` connections expose a single resource named `files` (`FROM buckets` or `FROM buckets.files`); iceberg resources are the onboarded tables — address one as `FROM iceberg.NAMESPACE_TABLE` (dots become underscores, same case as onboarded) or by its bare table name.
-- `ingest` connections are independent of `hotdata connections` (the federated-query store) — ingest owns its own credentials.
+- Table names per type: `buckets` datasources expose one table named `files` (`FROM <name>` or `FROM <name>.files`); iceberg tables are addressed by the exact onboarded name (`FROM ice."ns.orders"`), the underscored form (`FROM ice.ns_orders`), or the bare table name — `show-datasource` lists what was discovered.
+- `ingest` datasources are separate from `hotdata connections` (live, synced views for federated queries): an ingest **copies data in**, a connection stays live at the source.
+- The pre-0.14 `*-connection` verbs still work as hidden aliases of the `*-datasource` ones.
 
 ### Usage
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,8 +133,8 @@ pub enum Commands {
         command: Option<JobsCommands>,
     },
 
-    /// Ingest data from external connectors (databases, REST APIs, files, Iceberg)
-    /// into a managed database via the hotdata ingest service
+    /// Pull data from external sources (databases, APIs, buckets, Iceberg)
+    /// into managed databases: datasources + imports
     Ingest {
         /// Workspace ID (defaults to first workspace from login)
         #[arg(long, short = 'w', global = true)]

--- a/src/client/ingest.rs
+++ b/src/client/ingest.rs
@@ -62,8 +62,8 @@ impl IngestError {
             IngestError::Connection(e) => format!("connection error: {e}"),
             IngestError::Decode(e) => format!("malformed response: {e}"),
             IngestError::NeedsApiKey => {
-                "enqueueing an ingest requires a durable API key — the ingest pipeline \
-                 runs after a short-lived session token would expire"
+                "this command needs a workspace API key (hd_...) — a login session \
+                 cannot be used here"
                     .into()
             }
         }
@@ -121,8 +121,8 @@ impl IngestError {
         {
             eprintln!(
                 "{}",
-                "Your CLI session is user-scoped; ingest needs a workspace credential — \
-                 pass --api-key or set HOTDATA_API_KEY."
+                "This command needs workspace access — pass --api-key or set \
+                 HOTDATA_API_KEY with a workspace API key (hd_...)."
                     .dark_grey()
             );
         }
@@ -376,6 +376,10 @@ pub struct IngestRequest {
     pub family: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub connector_type: Option<String>,
+    /// User-chosen datasource name — the FROM target for imports. Omitted →
+    /// the datasource answers to its connector name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[serde(skip_serializing_if = "serde_json::Value::is_null")]
     pub credentials: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -423,6 +427,8 @@ pub struct IngestAck {
     pub database_id: String,
     pub status: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
     pub status_url: Option<String>,
     #[serde(flatten)]
     pub extra: serde_json::Map<String, serde_json::Value>,
@@ -433,8 +439,15 @@ pub struct IngestAck {
 pub struct JobStatus {
     pub ingest_id: String,
     pub status: String,
+    /// Finer in-flight progress state (extracting/loading/…) — split from
+    /// `status` by newer servers; the command layer falls back to a
+    /// stage-shaped `status` for older ones.
+    #[serde(default)]
+    pub stage: Option<String>,
     #[serde(default)]
     pub detail: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(default)]
     pub connector_type: Option<String>,
     #[serde(default)]
@@ -451,6 +464,8 @@ pub struct JobStatus {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DeleteSourceAck {
     pub ingest_id: String,
+    #[serde(default)]
+    pub name: Option<String>,
     #[serde(default)]
     pub connector_type: Option<String>,
     #[serde(default)]
@@ -472,12 +487,16 @@ pub struct SourcesResponse {
 pub struct SourceRow {
     pub ingest_id: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
     pub connector_type: Option<String>,
     #[serde(default)]
     pub family: Option<String>,
     #[serde(default)]
     pub database_id: Option<String>,
     pub status: String,
+    #[serde(default)]
+    pub stage: Option<String>,
     #[serde(default)]
     pub detail: Option<String>,
     #[serde(default)]
@@ -502,6 +521,8 @@ pub struct QueryRow {
     pub ingest_id: String,
     pub source_ingest_id: String,
     #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
     pub connector_type: Option<String>,
     #[serde(default)]
     pub family: Option<String>,
@@ -510,6 +531,8 @@ pub struct QueryRow {
     #[serde(default)]
     pub database_id: Option<String>,
     pub status: String,
+    #[serde(default)]
+    pub stage: Option<String>,
     #[serde(default)]
     pub detail: Option<String>,
     #[serde(default)]
@@ -538,6 +561,9 @@ pub struct ConnectorEntry {
     pub auth: Option<String>,
     #[serde(default)]
     pub template: Option<serde_json::Value>,
+    /// JSON Schema for the entry's `--config` payload (generic families).
+    #[serde(default)]
+    pub config_schema: Option<serde_json::Value>,
 }
 
 #[cfg(test)]

--- a/src/commands/ingest.rs
+++ b/src/commands/ingest.rs
@@ -1,37 +1,42 @@
 //! `hotdata ingest` — pull data from external sources into a managed database.
 //!
-//! Two nouns, named explicitly in every command: **connections** (onboarded,
+//! Two nouns, named explicitly in every command: **datasources** (added,
 //! credentialed sources — schema discovered, no data loaded) and **imports**
-//! (managed DBs materialized from a connection). Commands: `new-connection`,
-//! `list-connections`, `connectors` (the catalog), `new-import` (--all or
-//! SQL), `list-imports`, `trigger-import` (re-run: refresh an ingest's DB
-//! from source), `status` (one-shot or `--wait` attach). The pre-rename verb
-//! aliases (`new`/`list`/`import`/`update`) were removed in 0.13.1.
+//! (managed DBs materialized from a datasource). Commands: `new-datasource`,
+//! `list-datasources`, `connectors` (the catalog), `new-import` (--all or
+//! SQL), `list-imports`, `trigger-import` (re-run: refresh an import's DB
+//! from source), `status` (one-shot or `--wait` attach). The 0.13
+//! `*-connection` verbs survive as hidden aliases (the noun collided with
+//! the federated `hotdata connections` store).
 //!
-//! **Imports don't block.** `new-import` and `trigger-import` enqueue, fire
-//! the drain, print the ingest id, and return; progress is tracked with
-//! `status <id> [--wait]` or `list-imports`. `--wait` opts into the old
-//! blocking poll. `new-connection` is the deliberate exception — it blocks
-//! by default because its output IS the feedback (credentials validated,
-//! schema discovered); `--no-wait` opts out.
+//! **Imports don't block.** `new-import` and `trigger-import` submit, print
+//! the import id, and return; progress is tracked with `status <id>
+//! [--wait]` or `list-imports`. `--wait` opts into the old blocking poll.
+//! `new-datasource` is the deliberate exception — it blocks by default
+//! because its output IS the feedback (credentials validated, schema
+//! discovered); `--no-wait` opts out.
 //!
-//! `new-connection` **adds a connection and discovers its schema — it loads no
-//! data** (the server's `validate_only` mode: check credentials, reflect the
-//! schema, cap extraction). It runs the guided wizard when no `--service` is
-//! given on a terminal, and is flag-driven otherwise (`--service` given, a
-//! non-TTY, or `--no-input`) — one command, two front doors. Pulling rows is
-//! the separate, explicit `new-import` step, read back through the core
+//! `new-datasource` **adds a datasource and discovers its schema — it loads
+//! no data**. It runs the guided wizard when no `--service` is given on a
+//! terminal, and is flag-driven otherwise (`--service` given, a non-TTY, or
+//! `--no-input`) — one command, two front doors. Pulling rows is the
+//! separate, explicit `new-import` step, read back through the core
 //! `query`/`databases`/`results` commands.
 //!
 //! The wizard is catalog-driven: the `/ingest/connectors` catalog returns a
-//! `template` per REST service with the `base_url`, auth shape, and resources
-//! already filled in, so the user only supplies the `<PLACEHOLDER>` secrets —
-//! never a URL the catalog already knows. Enqueueing needs a durable `hd_` API
-//! key (`--api-key`/`HOTDATA_API_KEY`); results land in the authenticated
-//! workspace — there is no destination flag by design.
+//! `template` per REST service with everything but the `<PLACEHOLDER>`
+//! secrets filled in, so the user only supplies those. Submitting needs a
+//! durable `hd_` API key (`--api-key`/`HOTDATA_API_KEY`); results land in
+//! the authenticated workspace — there is no destination flag by design.
+//!
+//! **Presentation contract:** user-facing output speaks datasource / import
+//! / database, never the service's job vocabulary. `status` is a closed set
+//! (pending | running | done | failed); the service's finer progress states
+//! ride in `stage`. JSON output projects the same user-facing fields (`id`,
+//! `name`, `type`, `status`, `stage`, …), not the wire rows.
 
 use crate::client::ingest::{
-    ConnectorEntry, IngestAck, IngestClient, IngestRequest, QueryToIngest,
+    ConnectorEntry, IngestAck, IngestClient, IngestRequest, JobStatus, QueryToIngest,
 };
 use crate::commands::prompt::{
     ask_secret, ask_text, optional, optional_default, prompt_list, select_optional,
@@ -40,12 +45,13 @@ use crate::util;
 use inquire::{Select, Text};
 use std::time::{Duration, Instant};
 
-/// Status-poll cadence (what the hotdlt UI uses). Each poll is a control-store
-/// query on the worker, so this is deliberately not sub-second.
+/// Status-poll cadence (what the hotdlt UI uses). Each poll is a service-side
+/// read, so this is deliberately not sub-second.
 const POLL_INTERVAL: Duration = Duration::from_millis(2_500);
 
-/// A drain fired immediately after enqueue can miss the new row (control-store
-/// read lag). If a job sits pending this long, kick the drain again.
+/// A run kicked immediately after submitting can miss the new row (the
+/// service's reads lag writes briefly). If a job sits pending this long,
+/// kick processing again.
 const DRAIN_REKICK_AFTER: Duration = Duration::from_secs(30);
 
 /// Render a value for `-o json|yaml`, or fall through to the human branch.
@@ -81,12 +87,13 @@ fn with_spinner<T>(
 
 #[derive(clap::Subcommand)]
 pub enum IngestCommands {
-    /// Add a source connection and discover its schema (loads no data)
+    /// Add a datasource and discover its schema (loads no data)
     ///
     /// Interactive by default; pass `--service` with config flags to add
     /// non-interactively. Pull rows separately with `hotdata ingest
     /// new-import`; browse connectors with `hotdata ingest connectors`.
-    NewConnection {
+    #[command(alias = "new-connection")]
+    NewDatasource {
         #[command(flatten)]
         create: CreateArgs,
 
@@ -94,31 +101,31 @@ pub enum IngestCommands {
         wait: WaitArgs,
     },
 
-    /// Show a connection's details: status, database, discovered tables + columns
-    ShowConnection {
-        /// Connection id (from `list-connections`)
+    /// Show a datasource's details: status and discovered tables + columns
+    #[command(alias = "show-connection")]
+    ShowDatasource {
+        /// Datasource id (from `list-datasources`)
         id: String,
     },
 
-    /// Delete a connection: its registry entry, stored credentials, and
-    /// (by default) its schema-discovery database
+    /// Delete a datasource: its stored credentials and discovered schema
     ///
-    /// Existing imports keep working — each carries its own credential copy.
-    /// Deleting the active onboard makes the next-newest onboard of that
-    /// connector active again.
-    DeleteConnection {
-        /// Connection id (from `list-connections`)
+    /// Imports you've already run keep working — each carries its own
+    /// credential copy.
+    #[command(alias = "delete-connection")]
+    DeleteDatasource {
+        /// Datasource id (from `list-datasources`)
         id: String,
 
-        /// Keep the connection's schema-discovery database
-        #[arg(long = "keep-database")]
+        /// Keep the datasource's schema-preview database
+        #[arg(long = "keep-database", hide = true)]
         keep_database: bool,
     },
 
-    /// List the connections you've added (each has its own connection id)
-    ListConnections {
-        /// Include superseded onboards (older connections a newer onboard of
-        /// the same connector replaced)
+    /// List the datasources you've added (each has its own datasource id)
+    #[command(alias = "list-connections")]
+    ListDatasources {
+        /// Include datasources replaced by a newer one of the same name
         #[arg(long)]
         all: bool,
     },
@@ -129,22 +136,22 @@ pub enum IngestCommands {
         name: Option<String>,
     },
 
-    /// Import data from a connection into a managed database (--all or SQL)
+    /// Import data from a datasource into a managed database (--all or SQL)
     NewImport {
-        /// SELECT <cols|*> FROM <connection>[.<resource>] [WHERE …] [LIMIT n]
+        /// SELECT <cols|*> FROM <datasource>[.<table>] [WHERE …] [LIMIT n]
         sql: Option<String>,
 
         /// Import everything from --source (SELECT * with no LIMIT)
         #[arg(long, conflicts_with = "sql")]
         all: bool,
 
-        /// Connection to import from: a connector name (used in FROM) or a
-        /// connection id from `list-connections` (pins resolution)
+        /// Datasource to import from: a name (used in FROM) or a datasource
+        /// id from `list-datasources` (pins resolution)
         #[arg(long)]
         source: Option<String>,
 
         /// Reuse an existing managed database (by id) instead of minting one
-        #[arg(long = "database-id")]
+        #[arg(long = "database-id", hide = true)]
         database_id: Option<String>,
 
         #[command(flatten)]
@@ -154,27 +161,28 @@ pub enum IngestCommands {
     /// List your imports: the SQL behind each and the database it landed in
     ListImports,
 
-    /// Re-run an ingest: refresh its database from the source
+    /// Re-run an import: refresh its database from the source
     ///
-    /// The worker resets the ingest to pending and re-drains it; loads are
-    /// replace-mode, so the same managed database is refreshed with the
-    /// stored credentials — nothing is re-entered.
+    /// The same managed database is refreshed using the stored credentials —
+    /// nothing is re-entered. Also accepts a datasource id: re-checks the
+    /// credentials and refreshes the discovered schema.
     TriggerImport {
-        /// Ingest id: an import from `list-imports`, or a connection from
-        /// `list-connections` (re-validates and refreshes its schema)
+        /// Import id from `list-imports`, or a datasource id from
+        /// `list-datasources`
         id: String,
 
         #[command(flatten)]
         poll: PollArgs,
     },
 
-    /// Show an ingest's status (an import or a connection onboard)
+    /// Show an import's or datasource's status
     ///
     /// One-shot by default with script-friendly exit codes: 0 done,
     /// 1 failed, 2 still in flight. `--wait` attaches and polls to a
     /// terminal state instead.
     Status {
-        /// Ingest id (from `new-import`, `list-imports`, or `list-connections`)
+        /// Import or datasource id (from `new-import`, `list-imports`, or
+        /// `list-datasources`)
         id: String,
 
         #[command(flatten)]
@@ -187,8 +195,8 @@ pub enum IngestCommands {
 /// help text cannot drift between them.
 #[derive(clap::Args)]
 pub struct PollArgs {
-    /// Block until the ingest completes (default: return immediately; track
-    /// with `hotdata ingest status <id> --wait`)
+    /// Block until completion (default: return immediately; track with
+    /// `hotdata ingest status <id> --wait`)
     #[arg(long)]
     wait: bool,
 
@@ -197,13 +205,13 @@ pub struct PollArgs {
     wait_timeout: u64,
 }
 
-/// Wait flags for `new-connection` — the one enqueue command that still
+/// Wait flags for `new-datasource` — the one submit command that still
 /// blocks by default, because its output IS the feedback: did the
 /// credentials work, and what schema was discovered. The import commands
 /// return immediately and are tracked with `ingest status`.
 #[derive(clap::Args)]
 pub struct WaitArgs {
-    /// Enqueue only; print the ingest id and return without waiting
+    /// Submit only; print the datasource id and return without waiting
     #[arg(long = "no-wait")]
     no_wait: bool,
 
@@ -215,14 +223,14 @@ pub struct WaitArgs {
 /// Entry point from `main`. Keeps `main.rs` thin — one call per group.
 pub fn dispatch(workspace_id: &str, output: &str, command: IngestCommands) {
     match command {
-        IngestCommands::NewConnection { create, wait } => {
-            add_connection(workspace_id, output, create, &wait)
+        IngestCommands::NewDatasource { create, wait } => {
+            add_datasource(workspace_id, output, create, &wait)
         }
-        IngestCommands::ShowConnection { id } => show_connection(workspace_id, output, &id),
-        IngestCommands::DeleteConnection { id, keep_database } => {
-            delete_connection(workspace_id, output, &id, keep_database)
+        IngestCommands::ShowDatasource { id } => show_datasource(workspace_id, output, &id),
+        IngestCommands::DeleteDatasource { id, keep_database } => {
+            delete_datasource(workspace_id, output, &id, keep_database)
         }
-        IngestCommands::ListConnections { all } => list_connections(workspace_id, output, all),
+        IngestCommands::ListDatasources { all } => list_datasources(workspace_id, output, all),
         IngestCommands::Connectors { name } => catalog_list(workspace_id, name.as_deref(), output),
         IngestCommands::NewImport {
             sql,
@@ -239,28 +247,154 @@ pub fn dispatch(workspace_id: &str, output: &str, command: IngestCommands) {
     }
 }
 
-// --- new: add a connection (wizard or flag-driven) -----------------------
+// --- presentation helpers --------------------------------------------------
 
-/// `ingest new-connection`. The guided wizard runs when no connector was named and we're
-/// on a terminal; otherwise (a `--service` was given, or a non-TTY / `--no-input`
-/// run) it's flag-driven and needs `--service`.
-fn add_connection(workspace_id: &str, output: &str, args: CreateArgs, wait: &WaitArgs) {
+/// `status` as shown to users is a CLOSED set: pending | running | done |
+/// failed. Anything else the service reports is a finer in-flight stage —
+/// presented as `running` with the raw value demoted to the stage slot.
+/// (New servers already split status/stage; this also covers older ones.)
+fn normalize_status(raw: &str) -> (&'static str, Option<&str>) {
+    match raw {
+        "pending" => ("pending", None),
+        "running" => ("running", None),
+        "done" => ("done", None),
+        "failed" => ("failed", None),
+        stage => ("running", Some(stage)),
+    }
+}
+
+/// The (status, stage) pair for a job row: the server's `stage` field wins,
+/// a stage-shaped `status` from an older server is the fallback.
+fn presented_status(status: &str, stage: Option<&str>) -> (String, Option<String>) {
+    let (normalized, fallback) = normalize_status(status);
+    (
+        normalized.to_string(),
+        stage.map(str::to_string).or(fallback.map(str::to_string)),
+    )
+}
+
+/// STATUS cell for the human tables/details: the normalized status, with the
+/// in-flight stage in parentheses when there is one.
+fn status_cell(status: &str, stage: Option<&str>) -> String {
+    let (normalized, stage) = presented_status(status, stage);
+    let colored = util::color_status(&normalized);
+    match stage {
+        Some(s) => format!("{colored} ({s})"),
+        None => colored,
+    }
+}
+
+/// Display label for a wire family value. Datasource types read as product
+/// nouns (SQL, buckets, API), not protocol jargon.
+fn family_label(family: &str) -> &str {
+    match family {
+        "sql" => "SQL",
+        "filesystem" => "buckets",
+        "rest" => "API",
+        other => other,
+    }
+}
+
+/// Machine value for a wire family (`type` in json/yaml output): the same
+/// product nouns, lowercased for scripting.
+fn family_type(family: &str) -> &str {
+    match family {
+        "filesystem" => "buckets",
+        "rest" => "api",
+        other => other,
+    }
+}
+
+/// A datasource name is the FROM target for imports, so it must be a bare
+/// SQL-identifier-shaped word (the server enforces the same rule).
+fn valid_datasource_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    name.len() <= 64
+        && matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn checked_name(name: Option<String>) -> Option<String> {
+    if let Some(n) = name.as_deref()
+        && !valid_datasource_name(n)
+    {
+        fail(
+            "datasource names are letters, digits, and underscores (not starting \
+             with a digit) — they are the FROM target for imports",
+        );
+    }
+    name
+}
+
+/// The user-facing name of a job row: the datasource name, falling back to
+/// the connector for rows created before names existed.
+fn display_name(name: Option<&str>, connector_type: Option<&str>) -> Option<String> {
+    name.or(connector_type).map(str::to_string)
+}
+
+/// The user-facing json/yaml view of a job status. One projection shared by
+/// `status`, `show-datasource`, and the poll terminal states, so machine
+/// output never reverts to wire rows.
+fn status_json(st: &JobStatus) -> serde_json::Value {
+    let (status, stage) = presented_status(&st.status, st.stage.as_deref());
+    serde_json::json!({
+        "id": st.ingest_id,
+        "name": display_name(st.name.as_deref(), st.connector_type.as_deref()),
+        "connector": st.connector_type,
+        "type": st.family.as_deref().map(family_type),
+        "status": status,
+        "stage": stage,
+        "detail": st.detail,
+        "database_id": st.database_id,
+        "created_at": st.created_at,
+        "updated_at": st.updated_at,
+    })
+}
+
+fn family_rank(family: &str) -> u8 {
+    match family {
+        "sql" => 0,
+        "filesystem" => 1,
+        "iceberg" => 2,
+        _ => 3, // rest services
+    }
+}
+
+/// Sort the catalog for display: generic families (sql, filesystem, iceberg)
+/// first, then the REST services, each group alphabetical. Redundant SQL
+/// dialect aliases are collapsed at the source (the catalog), not here.
+fn sorted_for_display(entries: &[ConnectorEntry]) -> Vec<ConnectorEntry> {
+    let mut sorted = entries.to_vec();
+    sorted.sort_by(|a, b| {
+        family_rank(&a.family)
+            .cmp(&family_rank(&b.family))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    sorted
+}
+
+// --- new-datasource: wizard or flag-driven --------------------------------
+
+/// `ingest new-datasource`. The guided wizard runs when no connector was
+/// named and we're on a terminal; otherwise (a `--service` was given, or a
+/// non-TTY / `--no-input` run) it's flag-driven and needs `--service`.
+fn add_datasource(workspace_id: &str, output: &str, args: CreateArgs, wait: &WaitArgs) {
     if args.service.is_none() && util::is_interactive() {
         if args.any_given() {
             // The wizard prompts from scratch and would silently ignore
             // every provided flag — refuse instead of discarding input.
             fail(
                 "--service is required when other flags are given (e.g. --service postgres); \
-                 run plain 'hotdata ingest new-connection' for the guided wizard",
+                 run plain 'hotdata ingest new-datasource' for the guided wizard",
             );
         }
-        wizard(workspace_id, output, wait);
+        wizard(workspace_id, output, checked_name(args.name), wait);
     } else {
         add_from_flags(workspace_id, output, args, wait);
     }
 }
 
-fn wizard(workspace_id: &str, output: &str, wait: &WaitArgs) {
+fn wizard(workspace_id: &str, output: &str, name: Option<String>, wait: &WaitArgs) {
     let client = IngestClient::new(workspace_id);
     let entries = fetch_catalog(&client);
     let entry = select_connector(&entries);
@@ -271,7 +405,11 @@ fn wizard(workspace_id: &str, output: &str, wait: &WaitArgs) {
         "iceberg" => build_iceberg_interactive(&entry),
         _ => build_rest_interactive(&entry),
     };
-    // Adding a connection discovers the schema only — never loads data.
+    // A --name given up front is honored; otherwise offer one (blank keeps
+    // the connector name, which is what most people want).
+    req.name =
+        checked_name(name.or_else(|| optional(None, "Name (blank to use the connector name):")));
+    // Adding a datasource discovers the schema only — never loads data.
     req.validate_only = true;
     run_source(&client, output, wait.no_wait, wait.wait_timeout, req);
 }
@@ -302,41 +440,6 @@ fn select_connector(entries: &[ConnectorEntry]) -> ConnectorEntry {
         .unwrap_or_else(|_| std::process::exit(0));
     let idx = labels.iter().position(|l| l == &selected).unwrap();
     sorted[idx].clone()
-}
-
-fn family_rank(family: &str) -> u8 {
-    match family {
-        "sql" => 0,
-        "filesystem" => 1,
-        "iceberg" => 2,
-        _ => 3, // rest services
-    }
-}
-
-/// Display label for a wire family value. Connection types read as product
-/// nouns (SQL, buckets, API), not protocol jargon; json/yaml output keeps
-/// the wire values for scripting.
-fn family_label(family: &str) -> &str {
-    match family {
-        "sql" => "SQL",
-        "filesystem" => "buckets",
-        "rest" => "API",
-        other => other,
-    }
-}
-
-/// Sort the catalog for display: generic families (sql, filesystem, iceberg)
-/// first, then the REST services, each group alphabetical. Redundant SQL
-/// dialect aliases are collapsed at the source (the dlthubworker catalog), not
-/// here.
-fn sorted_for_display(entries: &[ConnectorEntry]) -> Vec<ConnectorEntry> {
-    let mut sorted = entries.to_vec();
-    sorted.sort_by(|a, b| {
-        family_rank(&a.family)
-            .cmp(&family_rank(&b.family))
-            .then_with(|| a.name.cmp(&b.name))
-    });
-    sorted
 }
 
 fn build_sql_interactive(entry: &ConnectorEntry) -> IngestRequest {
@@ -381,8 +484,8 @@ fn build_filesystem_interactive(entry: &ConnectorEntry) -> IngestRequest {
     let glob = optional(None, "File glob (e.g. **/*.parquet, blank for all):");
     IngestRequest {
         family: "filesystem".into(),
-        // connector_type is the registry name `new-import` resolves FROM —
-        // without it the connection lands unnamed and is un-importable.
+        // connector_type is what `new-import` resolves FROM when no name is
+        // chosen — without it the datasource lands unnamed and un-importable.
         connector_type: Some(entry.name.clone()),
         credentials: filesystem_credentials(),
         bucket_url: Some(bucket_url),
@@ -397,8 +500,8 @@ fn build_iceberg_interactive(entry: &ConnectorEntry) -> IngestRequest {
     let tables = prompt_list("Tables (namespace.table, comma-separated):");
     IngestRequest {
         family: "iceberg".into(),
-        // connector_type is the registry name `new-import` resolves FROM —
-        // without it the connection lands unnamed and is un-importable.
+        // connector_type is what `new-import` resolves FROM when no name is
+        // chosen — without it the datasource lands unnamed and un-importable.
         connector_type: Some(entry.name.clone()),
         catalog_name: Some(entry.name.clone()),
         catalog_type,
@@ -410,7 +513,7 @@ fn build_iceberg_interactive(entry: &ConnectorEntry) -> IngestRequest {
 
 /// REST family. A cataloged service carries a `template` with everything but
 /// the secrets filled in — walk it, prompt only the `<PLACEHOLDER>` tokens, and
-/// send the result. The bare `rest` entry (no template) falls back to building
+/// send the result. The bare `api` entry (no template) falls back to building
 /// a minimal config interactively.
 fn build_rest_interactive(entry: &ConnectorEntry) -> IngestRequest {
     match &entry.template {
@@ -424,7 +527,7 @@ fn build_rest_interactive(entry: &ConnectorEntry) -> IngestRequest {
             }
         }
         None => {
-            let name = ask_text("Connection name (names the connection for `ingest new-import`):");
+            let name = ask_text("Datasource name (the FROM target for `ingest new-import`):");
             IngestRequest {
                 family: "rest".into(),
                 connector_type: Some(name),
@@ -505,7 +608,7 @@ fn substitute_placeholder(v: &mut serde_json::Value, token: &str, value: &str) {
     }
 }
 
-// --- new (flag-driven): non-interactive add ------------------------------
+// --- new-datasource (flag-driven): non-interactive add --------------------
 
 #[derive(clap::Args)]
 pub struct CreateArgs {
@@ -514,8 +617,13 @@ pub struct CreateArgs {
     #[arg(long)]
     service: Option<String>,
 
-    /// Family payload as JSON (inline, @file.json, or @-): SQL credentials,
-    /// an API rest_config, buckets creds, or an Iceberg catalog_config
+    /// Name for the datasource — the FROM target for imports (default: the
+    /// connector name). Lets several datasources of one connector coexist.
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Connector config as JSON (inline, @file.json, or @-). Field reference:
+    /// `hotdata ingest connectors -o json` (each entry's config_schema)
     #[arg(long)]
     config: Option<String>,
 
@@ -544,13 +652,14 @@ pub struct CreateArgs {
     catalog_type: Option<String>,
 
     /// Reuse an existing managed database (by id) instead of minting one
-    #[arg(long = "database-id")]
+    #[arg(long = "database-id", hide = true)]
     database_id: Option<String>,
 }
 
 impl CreateArgs {
-    /// Any flag beyond `--service` — the wizard never reads these, so
-    /// entering it with any of them set would silently discard user input.
+    /// Any flag beyond `--service`/`--name` — the wizard never reads these,
+    /// so entering it with any of them set would silently discard user input.
+    /// (`--name` IS honored by the wizard, so it doesn't count.)
     fn any_given(&self) -> bool {
         self.config.is_some()
             || !self.tables.is_empty()
@@ -566,9 +675,9 @@ impl CreateArgs {
 fn add_from_flags(workspace_id: &str, output: &str, args: CreateArgs, wait: &WaitArgs) {
     let Some(service) = args.service.as_deref() else {
         eprintln!(
-            "error: --service is required to add a connection non-interactively. \
+            "error: --service is required to add a datasource non-interactively. \
              Browse connectors with 'hotdata ingest connectors', or run \
-             'hotdata ingest new-connection' in a terminal for the guided wizard."
+             'hotdata ingest new-datasource' in a terminal for the guided wizard."
         );
         std::process::exit(1);
     };
@@ -596,6 +705,15 @@ fn build_create_request(
     args: CreateArgs,
     config: Option<serde_json::Value>,
 ) -> Result<IngestRequest, String> {
+    if let Some(n) = args.name.as_deref()
+        && !valid_datasource_name(n)
+    {
+        return Err(
+            "datasource names are letters, digits, and underscores (not starting \
+             with a digit) — they are the FROM target for imports"
+                .into(),
+        );
+    }
     let mut req = match entry.family.as_str() {
         "sql" => IngestRequest {
             family: "sql".into(),
@@ -623,7 +741,7 @@ fn build_create_request(
             connector_type: Some(entry.name.clone()),
             catalog_name: Some(entry.name.clone()),
             catalog_type: args.catalog_type.or_else(|| Some("rest".into())),
-            catalog_config: Some(config.ok_or("iceberg needs --config with the catalog config")?),
+            catalog_config: Some(config.ok_or("iceberg needs --config with the catalog fields")?),
             tables: args.tables,
             ..Default::default()
         },
@@ -632,12 +750,12 @@ fn build_create_request(
             // which only works untouched for keyless services.
             let rest_config = config
                 .or_else(|| entry.template.clone())
-                .ok_or("this API connector needs --config with a rest_config")?;
+                .ok_or("this API connector needs --config (client + resources)")?;
             let mut leftover = Vec::new();
             collect_placeholders(&rest_config, &mut leftover);
             if !leftover.is_empty() {
                 return Err(format!(
-                    "connector '{}' needs secrets ({}) — pass a filled --config, or use 'hotdata ingest new-connection'",
+                    "connector '{}' needs secrets ({}) — pass a filled --config, or use 'hotdata ingest new-datasource'",
                     entry.name,
                     leftover.join(", ")
                 ));
@@ -650,8 +768,9 @@ fn build_create_request(
             }
         }
     };
-    // Adding a connection discovers the schema only — never loads data.
+    // Adding a datasource discovers the schema only — never loads data.
     req.validate_only = true;
+    req.name = args.name;
     req.database_id = args.database_id;
     Ok(req)
 }
@@ -664,26 +783,26 @@ fn catalog_list(workspace_id: &str, filter: Option<&str>, output: &str) {
         entries.retain(|c| c.name.to_lowercase().contains(&f));
     }
     let entries = sorted_for_display(&entries);
-    // "active" = a connector this workspace has already added (it appears in
-    // the onboarded-source registry). Best-effort: if the registry read fails
-    // the catalog still shows, just without active marks.
-    // Session JWTs are rejected on every workspace-scoped read (module docs
-    // in client/ingest) — don't pay a doomed round-trip for the marks.
-    let active = if client.has_api_key() {
-        active_source_names(&client)
+    // "added" = a connector this workspace already has a datasource for.
+    // Best-effort: if the read fails the catalog still shows, just without
+    // the marks. Login sessions are rejected on every workspace-scoped read
+    // (module docs in client/ingest) — don't pay a doomed round-trip.
+    let added = if client.has_api_key() {
+        added_connector_names(&client)
     } else {
         Default::default()
     };
-    let is_active = |name: &str| active.contains(name);
+    let is_added = |name: &str| added.contains(name);
 
     let projected: Vec<_> = entries
         .iter()
         .map(|c| {
             serde_json::json!({
                 "name": c.name,
-                "family": c.family,
-                "active": is_active(&c.name),
+                "type": family_type(&c.family),
+                "added": is_added(&c.name),
                 "description": c.description,
+                "config_schema": c.config_schema,
             })
         })
         .collect();
@@ -691,7 +810,7 @@ fn catalog_list(workspace_id: &str, filter: Option<&str>, output: &str) {
         let rows: Vec<Vec<String>> = entries
             .iter()
             .map(|c| {
-                let status = if is_active(&c.name) { "active" } else { "" };
+                let status = if is_added(&c.name) { "added" } else { "" };
                 vec![
                     c.name.clone(),
                     family_label(&c.family).to_string(),
@@ -700,14 +819,14 @@ fn catalog_list(workspace_id: &str, filter: Option<&str>, output: &str) {
                 ]
             })
             .collect();
-        crate::output::table::print(&["NAME", "FAMILY", "STATUS", "DESCRIPTION"], &rows);
+        crate::output::table::print(&["NAME", "TYPE", "STATUS", "DESCRIPTION"], &rows);
     });
 }
 
-/// Connector names this workspace has onboarded, from the sources registry.
-/// Used to flag which catalog connectors are active. Best-effort — an
-/// unavailable registry yields an empty set.
-fn active_source_names(client: &IngestClient) -> std::collections::HashSet<String> {
+/// Connector names this workspace has datasources for, used to flag the
+/// catalog's "added" marks. Best-effort — an unavailable listing yields an
+/// empty set.
+fn added_connector_names(client: &IngestClient) -> std::collections::HashSet<String> {
     client
         .list_sources(false)
         .map(|r| {
@@ -730,8 +849,8 @@ fn new_import(
     database_id: Option<String>,
     poll: &PollArgs,
 ) {
-    // A 32-char hex --source is a connection id (pins resolution); anything
-    // else is a connector name (the FROM target).
+    // A 32-char hex --source is a datasource id (pins resolution); anything
+    // else is a datasource name (the FROM target).
     let (pin, name) = match source {
         Some(s) if looks_like_ingest_id(&s) => (Some(s), None),
         Some(s) => (None, Some(s)),
@@ -739,13 +858,10 @@ fn new_import(
     };
 
     let client = IngestClient::new(workspace_id);
-    // `--all` against a pinned id needs the connector name for FROM — resolve
-    // it from the sources registry, only when actually needed.
+    // `--all` against a pinned id needs the datasource's name for FROM —
+    // resolve it, only when actually needed.
     let pinned_name = (all && name.is_none())
-        .then(|| {
-            pin.as_deref()
-                .and_then(|p| pinned_connector_name(&client, p))
-        })
+        .then(|| pin.as_deref().and_then(|p| pinned_source_name(&client, p)))
         .flatten();
     // A pin that fails to resolve is ITS OWN error — falling through to
     // build_import_query would blame the --source flag the user did pass.
@@ -755,7 +871,7 @@ fn new_import(
         && let Some(p) = pin.as_deref()
     {
         fail(&format!(
-            "could not resolve connection id {p} — check 'hotdata ingest list-connections'"
+            "could not resolve datasource id {p} — check 'hotdata ingest list-datasources'"
         ));
     }
     let query = build_import_query(sql, all, name.as_deref(), pinned_name.as_deref())
@@ -766,15 +882,15 @@ fn new_import(
         database_id,
     };
     let spinner = util::spinner("submitting import…");
-    // The by-name FROM lookup reads control-store snapshots that lag writes,
-    // so an import right after onboarding can 404 briefly. Retry ONCE: lag is
+    // The by-name FROM lookup reads snapshots that lag writes, so an import
+    // right after adding a datasource can 404 briefly. Retry ONCE: the lag is
     // usually under one poll interval, and every extra retry makes a typo'd
-    // connection name look like infrastructure lag for 2.5s more.
+    // datasource name look like a slow service for 2.5s more.
     let mut ack = client.create_query(&req);
     for _ in 0..1 {
         match &ack {
             Err(crate::client::ingest::IngestError::Http { status: 404, .. }) => {
-                spinner.set_message("waiting for the source to register…");
+                spinner.set_message("waiting for the datasource to appear…");
                 std::thread::sleep(POLL_INTERVAL);
                 ack = client.create_query(&req);
             }
@@ -798,11 +914,11 @@ fn new_import(
         render_done(&st, output);
         return;
     }
-    // Non-blocking default: the worker is on-demand, so fire the drain that
-    // actually processes the job — without it the import would sit pending —
-    // then hand the terminal back.
+    // Non-blocking default: the service processes on demand, so kick the run
+    // that actually executes the job — without it the import would sit
+    // pending — then hand the terminal back.
     let _ = client.drain();
-    render_ack(&ack, output);
+    render_ack(&ack, "import id:", output);
 }
 
 fn looks_like_ingest_id(s: &str) -> bool {
@@ -810,8 +926,8 @@ fn looks_like_ingest_id(s: &str) -> bool {
 }
 
 /// The SQL a `new-import` runs: explicit SQL wins; `--all` becomes a full
-/// `SELECT *` against the connection's name (`pinned_name` when --source was
-/// a connection id). Errors are messages for `fail`.
+/// `SELECT *` against the datasource's name (`pinned_name` when --source was
+/// a datasource id). Errors are messages for `fail`.
 fn build_import_query(
     sql: Option<String>,
     all: bool,
@@ -823,29 +939,30 @@ fn build_import_query(
         (None, true) => name
             .or(pinned_name)
             .map(|n| format!("SELECT * FROM {n}"))
-            .ok_or("--all needs --source <connection> (a connector name or connection id)"),
+            .ok_or("--all needs --source <datasource> (a name or datasource id)"),
         (None, false) => Err(
-            "provide SQL (SELECT … FROM <connection> …), or --all to import \
+            "provide SQL (SELECT … FROM <datasource> …), or --all to import \
              everything from --source",
         ),
     }
 }
 
-/// Resolve a pinned connection id to its connector name (the FROM target).
-/// GET /jobs/{id} returns it directly — no need to page the full registry.
-fn pinned_connector_name(client: &IngestClient, ingest_id: &str) -> Option<String> {
-    client.job_status(ingest_id).ok()?.connector_type
+/// Resolve a pinned datasource id to its name (the FROM target).
+/// GET /jobs/{id} returns it directly — no need to page the full listing.
+fn pinned_source_name(client: &IngestClient, ingest_id: &str) -> Option<String> {
+    let st = client.job_status(ingest_id).ok()?;
+    display_name(st.name.as_deref(), st.connector_type.as_deref())
 }
 
 // --- trigger-import --------------------------------------------------------
 
 fn trigger_import(workspace_id: &str, output: &str, id: &str, poll: &PollArgs) {
     let client = IngestClient::new(workspace_id);
-    // The worker resets the ingest to pending and fires the drain (409 if one
-    // is already mid-flight — its message says to retry shortly).
+    // The service resets the item to pending and runs it again (409 if a run
+    // is already in progress — its message says to retry shortly).
     let ack = with_spinner("requesting re-run…", || client.rerun(id));
     if poll.wait {
-        // The rerun already drained; poll only.
+        // The re-run has already been kicked; poll only.
         let st = poll_ingest(
             &client,
             output,
@@ -857,15 +974,15 @@ fn trigger_import(workspace_id: &str, output: &str, id: &str, poll: &PollArgs) {
         render_done(&st, output);
         return;
     }
-    render_ack(&ack, output);
+    render_ack(&ack, "import id:", output);
 }
 
 // --- status ------------------------------------------------------------------
 
 /// Exit code for a one-shot status check, mirroring `query status`:
-/// 0 done, 1 failed, 2 still in flight (pending/running/stage states).
+/// 0 done, 1 failed, 2 still in flight (pending/running).
 fn status_exit_code(status: &str) -> i32 {
-    match status {
+    match normalize_status(status).0 {
         "done" => 0,
         "failed" => 1,
         _ => 2,
@@ -875,19 +992,23 @@ fn status_exit_code(status: &str) -> i32 {
 fn status(workspace_id: &str, output: &str, id: &str, poll: &PollArgs) {
     let client = IngestClient::new(workspace_id);
     if poll.wait {
-        // Attach and poll to a terminal state. No initial drain kick — the
-        // enqueue already fired one — but the poll loop still re-kicks a job
-        // stuck in `pending` (control-store read lag), so attaching also
-        // rescues an import whose first drain missed the row.
+        // Attach and poll to a terminal state. No initial kick — the submit
+        // already fired one — but the poll loop still re-kicks a job stuck in
+        // `pending`, so attaching also rescues an import whose first run
+        // missed it.
         let st = poll_ingest(&client, output, id, poll.wait_timeout, "waiting", false);
         render_done(&st, output);
         return;
     }
     let st = client.job_status(id).unwrap_or_else(|e| e.exit());
-    render(output, &st, || {
+    render(output, &status_json(&st), || {
         use crossterm::style::Stylize;
         let label = |l: &str| format!("{:<14}", l).dark_grey().to_string();
-        println!("{}{}", label("status:"), util::color_status(&st.status));
+        println!(
+            "{}{}",
+            label("status:"),
+            status_cell(&st.status, st.stage.as_deref())
+        );
         if let Some(d) = st.detail.as_deref().filter(|d| !d.trim().is_empty()) {
             println!("{}{}", label("detail:"), d);
         }
@@ -907,22 +1028,42 @@ fn status(workspace_id: &str, output: &str, id: &str, poll: &PollArgs) {
     std::process::exit(status_exit_code(&st.status));
 }
 
-// --- list-connections ------------------------------------------------------
+// --- list-datasources ------------------------------------------------------
 
-fn list_connections(workspace_id: &str, output: &str, all: bool) {
+fn list_datasources(workspace_id: &str, output: &str, all: bool) {
     let client = IngestClient::new(workspace_id);
-    let resp = with_spinner("loading connections…", || client.list_sources(all));
+    let resp = with_spinner("loading datasources…", || client.list_sources(all));
 
-    render(output, &resp.sources, || {
+    let projected: Vec<_> = resp
+        .sources
+        .iter()
+        .map(|s| {
+            let (status, stage) = presented_status(&s.status, s.stage.as_deref());
+            serde_json::json!({
+                "id": s.ingest_id,
+                "name": display_name(s.name.as_deref(), s.connector_type.as_deref()),
+                "connector": s.connector_type,
+                "type": s.family.as_deref().map(family_type),
+                "status": status,
+                "stage": stage,
+                "detail": s.detail,
+                "database_id": s.database_id,
+                "created_at": s.created_at,
+                "updated_at": s.updated_at,
+                "active": s.active,
+            })
+        })
+        .collect();
+    render(output, &projected, || {
         use crossterm::style::Stylize;
         if resp.sources.is_empty() {
             eprintln!(
                 "{}",
-                "No connections yet. Add one with 'hotdata ingest new-connection'.".dark_grey()
+                "No datasources yet. Add one with 'hotdata ingest new-datasource'.".dark_grey()
             );
             return;
         }
-        let mut headers = vec!["NAME", "FAMILY", "STATUS", "CREATED", "CONNECTION ID"];
+        let mut headers = vec!["NAME", "TYPE", "STATUS", "CREATED", "DATASOURCE ID"];
         if all {
             headers.push("ACTIVE");
         }
@@ -935,13 +1076,14 @@ fn list_connections(workspace_id: &str, output: &str, all: bool) {
             .rev()
             .map(|s| {
                 let mut row = vec![
-                    s.connector_type.clone().unwrap_or_else(|| "-".into()),
+                    display_name(s.name.as_deref(), s.connector_type.as_deref())
+                        .unwrap_or_else(|| "-".into()),
                     s.family
                         .as_deref()
                         .map(family_label)
                         .unwrap_or_default()
                         .to_string(),
-                    util::color_status(&s.status),
+                    status_cell(&s.status, s.stage.as_deref()),
                     created_cell(s.created_at.as_deref()),
                     s.ingest_id.clone(),
                 ];
@@ -965,13 +1107,31 @@ fn list_imports(workspace_id: &str, output: &str) {
     let client = IngestClient::new(workspace_id);
     let resp = with_spinner("loading imports…", || client.list_queries());
 
-    render(output, &resp.queries, || {
+    let projected: Vec<_> = resp
+        .queries
+        .iter()
+        .map(|q| {
+            let (status, stage) = presented_status(&q.status, q.stage.as_deref());
+            serde_json::json!({
+                "id": q.ingest_id,
+                "datasource": display_name(q.name.as_deref(), q.connector_type.as_deref()),
+                "sql": q.query,
+                "status": status,
+                "stage": stage,
+                "detail": q.detail,
+                "database_id": q.database_id,
+                "created_at": q.created_at,
+                "updated_at": q.updated_at,
+            })
+        })
+        .collect();
+    render(output, &projected, || {
         use crossterm::style::Stylize;
         if resp.queries.is_empty() {
             eprintln!(
                 "{}",
                 "No imports yet. Create one with 'hotdata ingest new-import \
-                     --source <connection> --all' (or pass SQL)."
+                     --source <datasource> --all' (or pass SQL)."
                     .dark_grey()
             );
             return;
@@ -979,14 +1139,15 @@ fn list_imports(workspace_id: &str, output: &str) {
         let rows: Vec<Vec<String>> = resp
             .queries
             .iter()
-            // Oldest at the top, newest at the bottom (see list_connections).
+            // Oldest at the top, newest at the bottom (see list_datasources).
             .rev()
             .map(|q| {
                 vec![
                     q.ingest_id.clone(),
-                    q.connector_type.clone().unwrap_or_else(|| "-".into()),
+                    display_name(q.name.as_deref(), q.connector_type.as_deref())
+                        .unwrap_or_else(|| "-".into()),
                     q.query.clone().unwrap_or_default(),
-                    util::color_status(&q.status),
+                    status_cell(&q.status, q.stage.as_deref()),
                     created_cell(q.created_at.as_deref()),
                     q.database_id.clone().unwrap_or_else(|| "-".into()),
                 ]
@@ -995,7 +1156,7 @@ fn list_imports(workspace_id: &str, output: &str) {
         crate::output::table::print(
             &[
                 "IMPORT ID",
-                "SOURCE",
+                "DATASOURCE",
                 "SQL",
                 "STATUS",
                 "CREATED",
@@ -1021,17 +1182,17 @@ fn run_source(
     wait_timeout: u64,
     req: IngestRequest,
 ) {
-    // The first add in a workspace deploys the dlt runtime (~15-30s); later
-    // ones hash-short-circuit. The HTTP client allows 300s.
+    // The first add in a workspace provisions the runtime (~15-30s); later
+    // ones are quick. The HTTP client allows 300s.
     let ack = with_spinner(
-        "adding connection… (the first one in a workspace takes ~30s)",
+        "adding datasource… (the first one in a workspace takes ~30s)",
         || client.create_source(&req),
     );
     if no_wait {
-        // The worker is on-demand: without this drain the onboard would sit
-        // pending until some other command fires one.
+        // The service processes on demand: without this kick the datasource
+        // would sit pending until some other command fires one.
         let _ = client.drain();
-        render_ack(&ack, output);
+        render_ack(&ack, "datasource id:", output);
         return;
     }
     let st = poll_ingest(
@@ -1042,20 +1203,20 @@ fn run_source(
         "discovering schema",
         true,
     );
-    render_connection_added(client, &st, output);
+    render_datasource_added(client, &st, output);
 }
 
-/// The canonical "track this ingest" invocation. Every hint goes through
-/// here so the next verb rename has ONE string to update, not ten.
+/// The canonical "track this" invocation. Every hint goes through here so
+/// the next verb rename has ONE string to update, not ten.
 fn status_wait_hint(ingest_id: &str) -> String {
     format!("hotdata ingest status {ingest_id} --wait")
 }
 
 /// Timeout exit for a wait: code 2 = still in flight, distinct from 1 = the
-/// ingest itself failed. One place so every wait path agrees.
+/// run itself failed. One place so every wait path agrees.
 fn poll_timeout_exit(ingest_id: &str) -> ! {
     use crossterm::style::Stylize;
-    eprintln!("{}", "ingest timed out".red());
+    eprintln!("{}", "timed out waiting".red());
     eprintln!(
         "{}",
         format!("Keep tracking it with: {}", status_wait_hint(ingest_id)).dark_grey()
@@ -1063,22 +1224,22 @@ fn poll_timeout_exit(ingest_id: &str) -> ! {
     std::process::exit(2);
 }
 
-/// Poll the ingest to a terminal state, returning the final (done) status for
-/// the caller to render. `kick_drain` fires the drain up front (enqueue paths;
-/// `trigger-import` skips it — the rerun already drained). Every non-terminal
-/// status is shown live in the spinner (stage + detail); exits the process on
-/// failure (1) or timeout (2). On failure with `-o json|yaml` the status
-/// object (with the worker's detail) still lands on stdout, matching the
-/// one-shot `status` path.
+/// Poll to a terminal state, returning the final (done) status for the
+/// caller to render. `kick` fires processing up front (submit paths;
+/// `trigger-import` skips it — the re-run already did). Every in-flight
+/// stage is shown live in the spinner (stage + detail); exits the process on
+/// failure (1) or timeout (2). On failure with `-o json|yaml` the projected
+/// status object (with the server's detail) still lands on stdout, matching
+/// the one-shot `status` path.
 fn poll_ingest(
     client: &IngestClient,
     output: &str,
     ingest_id: &str,
     timeout_secs: u64,
     verb: &str,
-    kick_drain: bool,
-) -> crate::client::ingest::JobStatus {
-    if kick_drain {
+    kick: bool,
+) -> JobStatus {
+    if kick {
         let _ = client.drain();
     }
     let mut last_drain = Instant::now();
@@ -1103,7 +1264,7 @@ fn poll_ingest(
                 }
                 // The deadline outranks the retry budget: a transient blip AT
                 // the deadline is a timeout (exit 2 — the job may well still
-                // be running), not an ingest failure (exit 1).
+                // be running), not a failure (exit 1).
                 if Instant::now() > deadline {
                     spinner.finish_and_clear();
                     poll_timeout_exit(ingest_id);
@@ -1119,12 +1280,12 @@ fn poll_ingest(
             }
             "failed" => {
                 spinner.finish_and_clear();
-                // Machine formats get the status object (with the worker's
-                // detail) on stdout, matching one-shot `status`.
-                render(output, &st, || {
+                // Machine formats get the projected status object (with the
+                // server's detail) on stdout, matching one-shot `status`.
+                render(output, &status_json(&st), || {
                     use crossterm::style::Stylize;
                     let detail = st.detail.as_deref().unwrap_or("unknown error");
-                    eprintln!("{}", format!("ingest failed: {detail}").red());
+                    eprintln!("{}", format!("failed: {detail}").red());
                     if detail.contains("Forbidden") {
                         eprintln!(
                             "{}",
@@ -1136,16 +1297,19 @@ fn poll_ingest(
                 });
                 std::process::exit(1);
             }
-            // Any other status is in-progress. Surface it live rather than
-            // treating it as terminal — the worker reports stage-level states
-            // (e.g. extracting / normalizing / loading) and free-text detail as
-            // the pipeline advances, and the CLI shouldn't need to know the set.
-            stage => {
-                spinner.set_message(progress_message(verb, stage, st.detail.as_deref()));
-                // Re-kick the drain if the job never left `pending` — the
-                // enqueue-time drain can race the request row (harmless double
-                // drain; loads are replace-mode).
-                if stage == "pending" {
+            // Anything else is in flight. Surface the live stage + detail in
+            // the spinner rather than treating it as terminal.
+            raw => {
+                let (_, stage) = presented_status(raw, st.stage.as_deref());
+                spinner.set_message(progress_message(
+                    verb,
+                    stage.as_deref().unwrap_or(raw),
+                    st.detail.as_deref(),
+                ));
+                // Re-kick processing if the job never left `pending` — the
+                // submit-time kick can race the new row (a harmless double
+                // run; loads replace).
+                if raw == "pending" {
                     if last_drain.elapsed() > DRAIN_REKICK_AFTER {
                         let _ = client.drain();
                         last_drain = Instant::now();
@@ -1163,8 +1327,8 @@ fn poll_ingest(
     }
 }
 
-/// Spinner text for an in-progress poll: the verb plus the worker's current
-/// stage, and its free-text detail when present (e.g. row counts / table name).
+/// Spinner text for an in-progress poll: the verb plus the current stage,
+/// and its free-text detail when present (e.g. row counts / table name).
 fn progress_message(verb: &str, stage: &str, detail: Option<&str>) -> String {
     match detail.map(str::trim).filter(|d| !d.is_empty()) {
         Some(d) => format!("{verb}… {stage} — {d}"),
@@ -1174,12 +1338,16 @@ fn progress_message(verb: &str, stage: &str, detail: Option<&str>) -> String {
 
 // --- rendering -----------------------------------------------------------
 
-fn render_ack(ack: &IngestAck, output: &str) {
-    render(output, ack, || {
+fn render_ack(ack: &IngestAck, id_label: &str, output: &str) {
+    let machine = serde_json::json!({
+        "id": ack.ingest_id,
+        "database_id": ack.database_id,
+        "status": ack.status,
+    });
+    render(output, &machine, || {
         use crossterm::style::Stylize;
-        let label = |l: &str| format!("{:<14}", l).dark_grey().to_string();
-        println!("{}{}", label("ingest id:"), ack.ingest_id);
-        println!("{}{}", label("database:"), ack.database_id);
+        let label = |l: &str| format!("{:<15}", l).dark_grey().to_string();
+        println!("{}{}", label(id_label), ack.ingest_id);
         println!("{}{}", label("status:"), ack.status.as_str().yellow());
         println!(
             "{}",
@@ -1192,8 +1360,8 @@ fn render_ack(ack: &IngestAck, output: &str) {
     });
 }
 
-fn render_done(st: &crate::client::ingest::JobStatus, output: &str) {
-    render(output, st, || {
+fn render_done(st: &JobStatus, output: &str) {
+    render(output, &status_json(st), || {
         use crossterm::style::Stylize;
         let db = st.database_id.as_deref().unwrap_or("-");
         println!("{} → {}", "done".green(), db);
@@ -1204,31 +1372,23 @@ fn render_done(st: &crate::client::ingest::JobStatus, output: &str) {
     });
 }
 
-/// Render the result of adding a connection: the discovered schema (tables +
-/// columns), fetched from the schema-preview the metadata-only run landed. No
-/// data was loaded — the closing hint points at `import` for that.
-/// Machine view of a completed onboard: the job status plus the discovered
-/// schema. Typed (instead of mutating a serde_json::Value) so serialization
-/// cannot silently degrade to null.
-#[derive(serde::Serialize)]
-struct ConnectionAdded<'a> {
-    #[serde(flatten)]
-    status: &'a crate::client::ingest::JobStatus,
-    tables: Option<&'a serde_json::Value>,
+/// The user-facing json/yaml view of a datasource with its discovered
+/// schema: the status projection plus `tables`.
+fn datasource_json(st: &JobStatus, tables: Option<&serde_json::Value>) -> serde_json::Value {
+    let mut v = status_json(st);
+    v["tables"] = tables.cloned().unwrap_or(serde_json::Value::Null);
+    v
 }
 
-/// Fetch the schema-preview of a connection's discovery database: the raw
-/// `{"tables": {name: [columns]}}` value, when the DB exists and answers.
-fn discovered_tables(
-    client: &IngestClient,
-    st: &crate::client::ingest::JobStatus,
-) -> Option<serde_json::Value> {
+/// Fetch the schema-preview of a datasource: the raw
+/// `{"tables": {name: [columns]}}` value, when it exists and answers.
+fn discovered_tables(client: &IngestClient, st: &JobStatus) -> Option<serde_json::Value> {
     let db = st.database_id.as_deref().filter(|d| !d.is_empty())?;
     client.schema(db).ok()?.get("tables").cloned()
 }
 
 /// Human rendering of the discovered schema: one line per table with its
-/// column names. Shared by `new-connection` and `show-connection`.
+/// column names. Shared by `new-datasource` and `show-datasource`.
 fn print_discovered_tables(tables_value: Option<&serde_json::Value>) {
     use crossterm::style::Stylize;
     match tables_value.and_then(|t| t.as_object()) {
@@ -1252,24 +1412,22 @@ fn print_discovered_tables(tables_value: Option<&serde_json::Value>) {
     }
 }
 
-fn render_connection_added(
-    client: &IngestClient,
-    st: &crate::client::ingest::JobStatus,
-    output: &str,
-) {
+/// Render the result of adding a datasource: the discovered schema (tables +
+/// columns). No data was loaded — the closing hint points at `new-import`
+/// for that. The schema-preview database id stays out of the human view
+/// (it's plumbing); `-o json` carries it as `database_id`.
+fn render_datasource_added(client: &IngestClient, st: &JobStatus, output: &str) {
     let tables_value = discovered_tables(client, st);
 
-    let machine = ConnectionAdded {
-        status: st,
-        tables: tables_value.as_ref(),
-    };
-    render(output, &machine, || {
+    render(output, &datasource_json(st, tables_value.as_ref()), || {
         use crossterm::style::Stylize;
-        let source = st.connector_type.as_deref().unwrap_or("source");
-        println!("{} {}", "connection added".green(), source.dark_grey());
-        if let Some(db) = st.database_id.as_deref().filter(|d| !d.is_empty()) {
-            println!("{}{}", format!("{:<12}", "database:").dark_grey(), db);
-        }
+        let source = display_name(st.name.as_deref(), st.connector_type.as_deref())
+            .unwrap_or_else(|| "source".into());
+        println!(
+            "{} {}",
+            "datasource added".green(),
+            source.as_str().dark_grey()
+        );
         print_discovered_tables(tables_value.as_ref());
         println!(
             "{}",
@@ -1279,34 +1437,32 @@ fn render_connection_added(
     });
 }
 
-// --- show-connection / delete-connection ------------------------------------
+// --- show-datasource / delete-datasource ------------------------------------
 
-fn show_connection(workspace_id: &str, output: &str, id: &str) {
+fn show_datasource(workspace_id: &str, output: &str, id: &str) {
     let client = IngestClient::new(workspace_id);
     let st = client.job_status(id).unwrap_or_else(|e| e.exit());
     let tables_value = discovered_tables(&client, &st);
 
-    let machine = ConnectionAdded {
-        status: &st,
-        tables: tables_value.as_ref(),
-    };
-    render(output, &machine, || {
+    render(output, &datasource_json(&st, tables_value.as_ref()), || {
         use crossterm::style::Stylize;
         let label = |l: &str| format!("{:<14}", l).dark_grey().to_string();
         println!(
             "{}{}",
             label("name:"),
-            st.connector_type.as_deref().unwrap_or("-")
+            display_name(st.name.as_deref(), st.connector_type.as_deref())
+                .unwrap_or_else(|| "-".into())
         );
         if let Some(f) = st.family.as_deref() {
-            println!("{}{}", label("family:"), family_label(f));
+            println!("{}{}", label("type:"), family_label(f));
         }
-        println!("{}{}", label("status:"), util::color_status(&st.status));
+        println!(
+            "{}{}",
+            label("status:"),
+            status_cell(&st.status, st.stage.as_deref())
+        );
         if let Some(d) = st.detail.as_deref().filter(|d| !d.trim().is_empty()) {
             println!("{}{}", label("detail:"), d);
-        }
-        if let Some(db) = st.database_id.as_deref() {
-            println!("{}{}", label("database:"), db);
         }
         if let Some(t) = st.created_at.as_deref() {
             println!("{}{}", label("created:"), util::format_date(t));
@@ -1318,12 +1474,12 @@ fn show_connection(workspace_id: &str, output: &str, id: &str) {
     });
 }
 
-fn delete_connection(workspace_id: &str, output: &str, id: &str, keep_database: bool) {
+fn delete_datasource(workspace_id: &str, output: &str, id: &str, keep_database: bool) {
     let client = IngestClient::new(workspace_id);
-    let ack = with_spinner("deleting connection…", || client.delete_source(id));
+    let ack = with_spinner("deleting datasource…", || client.delete_source(id));
 
-    // Drop the discovery database first so the ack (json/yaml) is the last
-    // thing on stdout for scripting.
+    // Drop the schema-preview database first so the ack (json/yaml) is the
+    // last thing on stdout for scripting.
     match ack.database_id.as_deref() {
         Some(db) if !keep_database => crate::commands::databases::delete(workspace_id, db),
         Some(db) => {
@@ -1335,12 +1491,20 @@ fn delete_connection(workspace_id: &str, output: &str, id: &str, keep_database: 
         }
         None => {}
     }
-    render(output, &ack, || {
+    let machine = serde_json::json!({
+        "id": ack.ingest_id,
+        "name": display_name(ack.name.as_deref(), ack.connector_type.as_deref()),
+        "deleted": ack.deleted,
+    });
+    render(output, &machine, || {
         use crossterm::style::Stylize;
         println!(
             "{} {}",
-            "connection deleted".green(),
-            ack.connector_type.as_deref().unwrap_or(id).dark_grey()
+            "datasource deleted".green(),
+            display_name(ack.name.as_deref(), ack.connector_type.as_deref())
+                .unwrap_or_else(|| id.to_string())
+                .as_str()
+                .dark_grey()
         );
     });
 }
@@ -1351,7 +1515,7 @@ fn fetch_catalog(client: &IngestClient) -> Vec<ConnectorEntry> {
     with_spinner("loading connectors…", || client.connectors()).connectors
 }
 
-/// Bare `rest` family: build a minimal dlt rest_api config interactively
+/// Bare `api` connector: build a minimal API config interactively
 /// (base_url + optional bearer token + resource paths).
 fn rest_config() -> serde_json::Value {
     let base_url = ask_text("API base URL:");
@@ -1373,8 +1537,8 @@ fn rest_config() -> serde_json::Value {
     serde_json::json!({ "client": client, "resources": resources })
 }
 
-/// Filesystem object-store credentials: prompt for S3-style creds (all optional
-/// — blank access key = public bucket, no creds sent).
+/// Bucket credentials: prompt for S3-style creds (all optional — blank
+/// access key = public bucket, no creds sent).
 fn filesystem_credentials() -> serde_json::Value {
     if !util::is_interactive() {
         return serde_json::Value::Null;
@@ -1399,11 +1563,10 @@ fn filesystem_credentials() -> serde_json::Value {
 }
 
 /// Iceberg catalog connection config: prompt for catalog URI + warehouse +
-/// token + namespace.
+/// token + namespace. Field reference: the `iceberg` entry's config_schema
+/// in `hotdata ingest connectors -o json`.
 fn iceberg_catalog_config() -> serde_json::Value {
     let mut m = serde_json::Map::new();
-    // pyiceberg's load_catalog requires the key "uri" (not "catalog_uri") —
-    // the worker passes this map to it verbatim.
     m.insert("uri".into(), ask_text("Catalog URI:").into());
     if let Some(w) = optional(None, "Warehouse (blank if none):") {
         m.insert("warehouse".into(), w.into());
@@ -1523,13 +1686,13 @@ mod tests {
     }
 
     #[test]
-    fn import_query_all_uses_the_connection_name() {
+    fn import_query_all_uses_the_datasource_name() {
         // Named source.
         assert_eq!(
             build_import_query(None, true, Some("bitcoin"), None).unwrap(),
             "SELECT * FROM bitcoin"
         );
-        // Pinned connection id — name resolved from the registry by the caller.
+        // Pinned datasource id — name resolved by the caller.
         assert_eq!(
             build_import_query(None, true, None, Some("postgres")).unwrap(),
             "SELECT * FROM postgres"
@@ -1549,6 +1712,7 @@ mod tests {
     fn create_args() -> CreateArgs {
         CreateArgs {
             service: None,
+            name: None,
             config: None,
             tables: Vec::new(),
             schema: None,
@@ -1574,15 +1738,29 @@ mod tests {
         args.schema = Some("tpch_sf1".into());
         args.tables = vec!["region".into()];
         args.database_id = Some("db_1".into());
+        args.name = Some("prod_pg".into());
         let req = build_create_request(&e, args, Some(creds.clone())).unwrap();
         assert_eq!(req.family, "sql");
         assert_eq!(req.connector_type.as_deref(), Some("postgres"));
         assert_eq!(req.credentials, creds);
         assert_eq!(req.schema.as_deref(), Some("tpch_sf1"));
         assert_eq!(req.table_names, vec!["region"]);
-        // Onboards never load data, and the db reuse flag rides through.
+        // Never loads data; the name and db-reuse flag ride through.
         assert!(req.validate_only);
+        assert_eq!(req.name.as_deref(), Some("prod_pg"));
         assert_eq!(req.database_id.as_deref(), Some("db_1"));
+    }
+
+    #[test]
+    fn create_request_rejects_invalid_names() {
+        let e = entry("postgres", "sql");
+        let creds = serde_json::json!({"connection_string": "postgresql://u:p@h/db"});
+        for bad in ["prod pg", "1pg", "pg-prod", ""] {
+            let mut args = create_args();
+            args.name = Some(bad.into());
+            let err = build_create_request(&e, args, Some(creds.clone())).unwrap_err();
+            assert!(err.contains("datasource names"), "{bad}: {err}");
+        }
     }
 
     #[test]
@@ -1597,7 +1775,7 @@ mod tests {
         fs_args.bucket_url = Some("s3://bucket/prefix".into());
         let req = build_create_request(&fs, fs_args, None).unwrap();
         assert_eq!(req.bucket_url.as_deref(), Some("s3://bucket/prefix"));
-        // Named in the registry (connector_type), or new-import can't FROM it.
+        // Registered under the connector name, or new-import can't FROM it.
         assert_eq!(req.connector_type.as_deref(), Some("buckets"));
 
         let ice = entry("iceberg", "iceberg");
@@ -1612,7 +1790,7 @@ mod tests {
         // The catalog type defaults to rest when not specified.
         assert_eq!(req.catalog_type.as_deref(), Some("rest"));
         assert_eq!(req.tables, vec!["ns.t"]);
-        // Named in the registry (connector_type), or new-import can't FROM it.
+        // Registered under the connector name, or new-import can't FROM it.
         assert_eq!(req.connector_type.as_deref(), Some("iceberg"));
     }
 
@@ -1634,14 +1812,44 @@ mod tests {
     }
 
     #[test]
-    fn status_exit_codes_mirror_query_status() {
+    fn status_exit_codes_close_over_stage_states() {
         assert_eq!(status_exit_code("done"), 0);
         assert_eq!(status_exit_code("failed"), 1);
-        // Everything else is in flight — including worker stage states the
-        // CLI doesn't enumerate (extracting/normalizing/loading).
+        // Everything else is in flight — including stage states from older
+        // servers that report them through `status`.
         assert_eq!(status_exit_code("pending"), 2);
         assert_eq!(status_exit_code("running"), 2);
         assert_eq!(status_exit_code("loading"), 2);
+    }
+
+    #[test]
+    fn statuses_normalize_to_the_closed_set() {
+        assert_eq!(normalize_status("done"), ("done", None));
+        assert_eq!(normalize_status("pending"), ("pending", None));
+        // Old servers report stages through status — presented as running.
+        assert_eq!(
+            normalize_status("extracting"),
+            ("running", Some("extracting"))
+        );
+        // A server-provided stage field wins over the fallback.
+        assert_eq!(
+            presented_status("running", Some("loading")),
+            ("running".into(), Some("loading".into()))
+        );
+        assert_eq!(
+            presented_status("normalizing", None),
+            ("running".into(), Some("normalizing".into()))
+        );
+    }
+
+    #[test]
+    fn datasource_names_are_identifier_shaped() {
+        assert!(valid_datasource_name("prod_pg"));
+        assert!(valid_datasource_name("_x2"));
+        assert!(!valid_datasource_name("2fast"));
+        assert!(!valid_datasource_name("prod pg"));
+        assert!(!valid_datasource_name("prod-pg"));
+        assert!(!valid_datasource_name(""));
     }
 
     #[test]
@@ -1661,11 +1869,40 @@ mod tests {
     }
 
     #[test]
-    fn family_labels_read_as_product_nouns() {
+    fn family_labels_and_types_read_as_product_nouns() {
         assert_eq!(family_label("sql"), "SQL");
         assert_eq!(family_label("filesystem"), "buckets");
         assert_eq!(family_label("rest"), "API");
         assert_eq!(family_label("iceberg"), "iceberg");
+        // Machine values: same nouns, scripting-cased.
+        assert_eq!(family_type("sql"), "sql");
+        assert_eq!(family_type("filesystem"), "buckets");
+        assert_eq!(family_type("rest"), "api");
+        assert_eq!(family_type("iceberg"), "iceberg");
+    }
+
+    #[test]
+    fn status_json_projects_user_fields_not_wire_fields() {
+        let st = JobStatus {
+            ingest_id: "a".repeat(32),
+            status: "extracting".into(),
+            detail: Some("orders".into()),
+            name: None,
+            stage: None,
+            connector_type: Some("postgres".into()),
+            family: Some("sql".into()),
+            database_id: Some("db-1".into()),
+            created_at: None,
+            updated_at: Some("2026-07-09T10:00:00+00:00".into()),
+        };
+        let v = status_json(&st);
+        assert_eq!(v["id"], "a".repeat(32));
+        assert_eq!(v["name"], "postgres"); // falls back to the connector
+        assert_eq!(v["type"], "sql");
+        assert_eq!(v["status"], "running"); // normalized...
+        assert_eq!(v["stage"], "extracting"); // ...with the stage split out
+        assert!(v.get("ingest_id").is_none());
+        assert!(v.get("family").is_none());
     }
 
     #[test]
@@ -1681,6 +1918,7 @@ mod tests {
             description: String::new(),
             auth: None,
             template: None,
+            config_schema: None,
         }
     }
 


### PR DESCRIPTION
Tier A of the ingest-simplification proposal plus the datasources rename. Pairs with hotdata-dev/dlthubworker#79 — **deploy the worker first** (the CLI degrades gracefully against older servers: name falls back to the connector, stage falls back from stage-shaped statuses).

## What changes

- **Verbs**: `new-connection` / `list-connections` / `show-connection` / `delete-connection` → `new-datasource` / `list-datasources` / `show-datasource` / `delete-datasource`. The old verbs remain as hidden aliases, avoiding the noun collision with the federated `hotdata connections` store.
- **Named datasources**: `new-datasource --name prod_pg` (wizard prompts too). The name is the FROM target for imports, so several datasources of one connector coexist. Identifier-shaped, validated client-side.
- **Closed status set**: user-visible `status` ∈ pending|running|done|failed; stage states show as `running (extracting)` and ride a `stage` field in `-o json`.
- **BREAKING — machine output is a projection now**: `id`/`name`/`type` (sql|buckets|api|iceberg)/`status`/`stage`/`datasource`… instead of wire rows (`ingest_id`/`connector_type`/`family`). Acks drop internal workspace fields.
- **Vocabulary sweep** across help, output, and errors: no enqueue/drain/worker/onboard/superseded/replace-mode. The API-key error says what to do, not how the pipeline works.
- **connectors**: STATUS column shows `added`; `-o json` includes each entry's `config_schema` — the published `--config` contract (referenced from `--config` help and the skill).
- **Hidden plumbing**: `--database-id`, `--keep-database` still work but are out of `--help`; datasource human output leads with discovered tables, not a raw database id.
- **Docs**: README ingest section + `skills/hotdata/SKILL.md` rewritten (closed statuses, config_schema pointer, datasource vocabulary, no third-party library references).

## Tests

280 unit + all integration tests pass; new coverage for status normalization, the status/stage projection, name validation, and the `type` mapping. `cargo fmt` + clippy clean on touched files.