### PR TITLE
feat(cli): loading indicators for indexes list and usage

### DIFF
--- a/src/commands/databases.rs
+++ b/src/commands/databases.rs
@@ -398,8 +398,12 @@ fn list_database_summaries(api: &Api) -> Result<Vec<DatabaseSummary>, ApiError> 
 /// rediscovers managed databases here and resolves each one's
 /// `default_connection_id` via [`get_database`]. The list summary omits the
 /// connection id, hence ids only.
+///
+/// Deliberately spinner-less (plain [`block`], unlike
+/// [`list_database_summaries`]): the caller owns its own "Loading indexes…"
+/// spinner, and two indicatif bars would fight over the same line.
 pub(crate) fn list_database_ids(api: &Api) -> Result<Vec<String>, ApiError> {
-    list_database_summaries(api).map(|dbs| dbs.into_iter().map(|d| d.id).collect())
+    block(api.client().databases().list()).map(|r| r.databases.into_iter().map(|d| d.id).collect())
 }
 
 fn fetch_database(api: &Api, id: &str) -> Database {

--- a/src/commands/indexes.rs
+++ b/src/commands/indexes.rs
@@ -500,6 +500,11 @@ pub fn list(
 ) {
     let api = Api::new(Some(workspace_id));
 
+    // One spinner over the whole fetch — the unscoped path is a
+    // whole-workspace scan (many requests) that otherwise sits silent.
+    // The database discovery inside is deliberately spinner-less
+    // (databases::list_database_ids) so nothing fights for the line.
+    let spinner = crate::util::spinner("Loading indexes…");
     let (rows, multi_table) = match (connection_id, schema, table) {
         (Some(cid), Some(sch), Some(tbl)) => {
             let indexes = list_one_table(&api, cid, sch, tbl);
@@ -517,6 +522,7 @@ pub fn list(
             true,
         ),
     };
+    spinner.finish_and_clear();
 
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(&rows).unwrap()),

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -41,7 +41,10 @@ pub fn usage(workspace_id: &str, since: Option<&str>, format: &str) {
     let query: Vec<(&str, String)> = since
         .map(|s| vec![("since", s.to_string())])
         .unwrap_or_default();
-    let u: Usage = api.get_json("/usage", &query).unwrap_or_else(|e| e.exit());
+    let spinner = crate::util::spinner("Loading usage…");
+    let result = api.get_json("/usage", &query);
+    spinner.finish_and_clear();
+    let u: Usage = result.unwrap_or_else(|e| e.exit());
 
     match format {
         "json" => println!("{}", serde_json::to_string_pretty(&u).unwrap()),


### PR DESCRIPTION
Both commands sat silent while fetching:

- **`indexes list`**: one spinner over the whole fetch — the unscoped path is a whole-workspace scan (connections enumeration + managed-DB discovery + per-table index reads) that can take seconds. The database discovery inside the scan (`databases::list_database_ids`) becomes deliberately spinner-less so its nested "Loading databases…" bar never fights the outer one for the line; `databases list` itself keeps the wakeup-hint spinner.
- **`usage`**: plain spinner around its single request, cleared before rendering or error exit.

Smoke-tested both against prod.